### PR TITLE
Fix GitHub shell sync listeners and add widget coverage

### DIFF
--- a/test/widget/features/shell/presentation/main_shell_test.dart
+++ b/test/widget/features/shell/presentation/main_shell_test.dart
@@ -1,0 +1,182 @@
+import 'package:devhub_gpt/features/github/presentation/providers/github_providers.dart';
+import 'package:devhub_gpt/features/shell/presentation/main_shell.dart';
+import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
+import 'package:devhub_gpt/shared/providers/secure_storage_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+class _FakeSecureStorage extends FlutterSecureStorage {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    return _store[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    MacOsOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (value == null) {
+      _store.remove(key);
+    } else {
+      _store[key] = value;
+    }
+  }
+}
+
+class _FakeGithubSyncService extends GithubSyncService {
+  _FakeGithubSyncService(Ref ref) : super(ref);
+
+  final List<String> calls = [];
+
+  @override
+  Future<void> syncRepos() async {
+    calls.add('repos');
+  }
+
+  @override
+  Future<void> syncRecentCommits() async {
+    calls.add('commits');
+  }
+
+  @override
+  Future<void> syncAll() async {
+    calls.add('all');
+  }
+}
+
+typedef _Harness = ({
+  _FakeGithubSyncService sync,
+  ProviderContainer container,
+  _FakeSecureStorage storage,
+});
+
+Future<_Harness> _pumpShell(WidgetTester tester) async {
+  final storage = _FakeSecureStorage();
+  late _FakeGithubSyncService fakeSync;
+  final router = GoRouter(
+    initialLocation: '/dashboard',
+    routes: [
+      GoRoute(
+        path: '/dashboard',
+        builder: (context, state) => MainShell(child: const SizedBox()),
+      ),
+    ],
+  );
+
+  addTearDown(router.dispose);
+
+  tester.binding.window.physicalSizeTestValue = const Size(1400, 900);
+  tester.binding.window.devicePixelRatioTestValue = 1;
+
+  addTearDown(() {
+    tester.binding.window.clearPhysicalSizeTestValue();
+    tester.binding.window.clearDevicePixelRatioTestValue();
+  });
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        secureStorageProvider.overrideWithValue(storage),
+        githubSyncServiceProvider.overrideWith((ref) {
+          fakeSync = _FakeGithubSyncService(ref);
+          return fakeSync;
+        }),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+
+  final container =
+      ProviderScope.containerOf(tester.element(find.byType(MainShell)));
+
+  return (sync: fakeSync, container: container, storage: storage);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('performs an eager sync when the shell is built', (tester) async {
+    final harness = await _pumpShell(tester);
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 1);
+  });
+
+  testWidgets('triggers sync when GitHub token changes', (tester) async {
+    final harness = await _pumpShell(tester);
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 1);
+
+    await harness.storage.write(key: 'github_token', value: 'abc');
+    harness.container.invalidate(githubTokenProvider);
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 2);
+
+    // Re-invalidating without changing the token should not cause another sync.
+    harness.container.invalidate(githubTokenProvider);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 2);
+
+    // Clearing the token should not trigger a sync either.
+    await harness.storage.write(key: 'github_token', value: '');
+    harness.container.invalidate(githubTokenProvider);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 10));
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 2);
+  });
+
+  testWidgets('triggers sync when the session version increments',
+      (tester) async {
+    final harness = await _pumpShell(tester);
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 1);
+
+    final notifier =
+        harness.container.read(githubSessionVersionProvider.notifier);
+    notifier.state++;
+
+    await tester.pump();
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 2);
+  });
+
+  testWidgets('triggers sync when the app lifecycle resumes', (tester) async {
+    final harness = await _pumpShell(tester);
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 1);
+
+    tester.binding.handleAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+    await tester.pump();
+
+    expect(harness.sync.calls.where((c) => c == 'all').length, 2);
+  });
+}


### PR DESCRIPTION
## Summary
- import the shared GitHub token provider and switch MainShell listeners to `listenManual` so sync triggers compile and can run from `initState`
- close the manual subscriptions on dispose to prevent leaks
- add a widget-test harness with GoRouter to cover eager sync, token updates, session bumps, and lifecycle resume behaviour

## Testing
- flutter test test/widget/features/shell/presentation/main_shell_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68ccb150f0d88333a094a79384241ec8