### PR TITLE
Align commit chart tooltip with repository tooltip styling

### DIFF
--- a/lib/features/dashboard/presentation/widgets/commit_line_chart.dart
+++ b/lib/features/dashboard/presentation/widgets/commit_line_chart.dart
@@ -134,8 +134,10 @@ class _SegmentButton extends StatelessWidget {
       onTap: onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-        decoration:
-            BoxDecoration(borderRadius: BorderRadius.circular(8), color: bg),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(8),
+          color: bg,
+        ),
         child: Text(
           label,
           style: TextStyle(
@@ -155,8 +157,10 @@ class _SmoothLineChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxY =
-        (points.fold<int>(0, (m, p) => math.max(m, p.count))).clamp(0, 100000);
+    final maxY = (points.fold<int>(
+      0,
+      (m, p) => math.max(m, p.count),
+    )).clamp(0, 100000);
     final primary = Theme.of(context).colorScheme.primary;
     return _InteractiveChart(
       points: points,
@@ -184,11 +188,11 @@ class _InteractiveChartState extends State<_InteractiveChart> {
   int? hovered;
 
   Rect _chartRect(Size size) => Rect.fromLTWH(
-        _ChartPainter.padL,
-        _ChartPainter.padT,
-        size.width - _ChartPainter.padL - _ChartPainter.padR,
-        180 - _ChartPainter.padT - _ChartPainter.padB,
-      );
+    _ChartPainter.padL,
+    _ChartPainter.padT,
+    size.width - _ChartPainter.padL - _ChartPainter.padR,
+    180 - _ChartPainter.padT - _ChartPainter.padB,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -215,40 +219,62 @@ class _InteractiveChartState extends State<_InteractiveChart> {
               '${date.day.toString().padLeft(2, '0')}.${date.month.toString().padLeft(2, '0')}';
           final samples = p.samples;
           final theme = Theme.of(context);
+          final tooltipTheme = TooltipTheme.of(context);
+          final decoration =
+              tooltipTheme.decoration ??
+              BoxDecoration(
+                color: theme.colorScheme.inverseSurface,
+                borderRadius: BorderRadius.circular(4),
+              );
+          final padding =
+              tooltipTheme.padding ??
+              const EdgeInsets.symmetric(horizontal: 8, vertical: 6);
+          final textStyle =
+              tooltipTheme.textStyle ??
+              theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onInverseSurface,
+                height: 1.25,
+              );
+          final headerStyle =
+              tooltipTheme.textStyle?.copyWith(fontWeight: FontWeight.w600) ??
+              theme.textTheme.labelSmall?.copyWith(
+                color: textStyle?.color ?? theme.colorScheme.onInverseSurface,
+                fontWeight: FontWeight.w600,
+              );
+          final subtleStyle = textStyle?.copyWith(
+            color: (textStyle?.color ?? theme.colorScheme.onInverseSurface)
+                .withOpacity(0.7),
+          );
           final left = (pos.dx + 8).clamp(rect.left, rect.right - 280);
           final top = (pos.dy - 8 - 96).clamp(rect.top, rect.bottom - 96);
           return Positioned(
             left: left,
             top: top,
-            child: Material(
-              elevation: 4,
-              borderRadius: BorderRadius.circular(10),
-              color: theme.colorScheme.surface,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 280),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 280),
+              child: DecoratedBox(
+                decoration: decoration,
                 child: Padding(
-                  padding: const EdgeInsets.all(12),
+                  padding: padding,
                   child: DefaultTextStyle(
-                    style: theme.textTheme.bodySmall!,
+                    style:
+                        textStyle ??
+                        theme.textTheme.bodySmall!.copyWith(
+                          color: theme.colorScheme.onInverseSurface,
+                        ),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Text(
-                          '$label • ${p.count} commits',
-                          style: theme.textTheme.labelMedium
-                              ?.copyWith(fontWeight: FontWeight.w700),
-                        ),
-                        const SizedBox(height: 8),
+                        Text('$label • ${p.count} commits', style: headerStyle),
                         if (p.count > 0) ...[
+                          const SizedBox(height: 4),
                           for (final s in samples.take(3)) Text('• $s'),
                         ],
                         if (p.count > samples.length)
-                          Text(
-                            '• …',
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.outline,
-                            ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: 2),
+                            child: Text('• …', style: subtleStyle),
                           ),
                       ],
                     ),
@@ -420,8 +446,10 @@ class _ChartPainter extends CustomPainter {
         ),
         textDirection: TextDirection.ltr,
       )..layout();
-      final lx = (x - labelPainter.width / 2)
-          .clamp(chartRect.left, chartRect.right - labelPainter.width);
+      final lx = (x - labelPainter.width / 2).clamp(
+        chartRect.left,
+        chartRect.right - labelPainter.width,
+      );
       labelPainter.paint(canvas, Offset(lx, chartRect.bottom + 6));
     }
 


### PR DESCRIPTION
## Summary
- update the commit activity chart hover bubble to reuse the app tooltip theme so it matches repository and commit popovers
- respect tooltip padding and typography so the hover details inherit the same text and subtle coloring

## Testing
- flutter test *(fails: existing tests depend on Firebase initialization and other preconditions in the current workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc6438b8c8333b9f52766b5bdda24