### PR TITLE
Fix GitHub web OAuth redirect handling and add tests

### DIFF
--- a/lib/features/github/data/repositories/github_auth_repository_impl.dart
+++ b/lib/features/github/data/repositories/github_auth_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:devhub_gpt/core/errors/failures.dart';
 import 'package:devhub_gpt/core/utils/app_logger.dart';
 import 'package:devhub_gpt/features/github/data/datasources/github_oauth_remote_data_source.dart';
 import 'package:devhub_gpt/features/github/data/datasources/github_web_oauth_data_source.dart';
+import 'package:devhub_gpt/features/github/domain/entities/github_web_sign_in_result.dart';
 import 'package:devhub_gpt/features/github/domain/entities/oauth.dart';
 import 'package:devhub_gpt/features/github/domain/repositories/github_auth_repository.dart';
 import 'package:devhub_gpt/shared/network/token_store.dart';
@@ -14,11 +15,14 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
   GithubAuthRepositoryImpl(
     this._ds,
     this._store, {
-    GithubWebOAuthDataSource? web,
-  }) : _web = web;
+    GithubWebOAuthDataSourceBase? web,
+    bool? isWebOverride,
+  })  : _web = web,
+        _isWeb = isWebOverride ?? kIsWeb;
   final GithubOAuthRemoteDataSource _ds;
   final TokenStore _store;
-  final GithubWebOAuthDataSource? _web;
+  final GithubWebOAuthDataSourceBase? _web;
+  final bool _isWeb;
 
   Duration _resolveTtl({required bool remember, Duration? override}) =>
       override ?? _store.defaultTtl(rememberMe: remember);
@@ -28,7 +32,7 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
     required String clientId,
     String scope = 'repo read:user',
   }) async {
-    if (kIsWeb) {
+    if (_isWeb) {
       return const Left(
         AuthFailure(
           'GitHub Device Flow недоступний у браузері. Використайте pop-up вхід.',
@@ -113,26 +117,31 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
   }
 
   @override
-  Future<Either<Failure, String>> signInWithWeb({
+  Future<Either<Failure, GithubWebSignInResult>> signInWithWeb({
     List<String> scopes = const ['repo', 'read:user'],
     required bool rememberMe,
     Duration? ttl,
   }) async {
     try {
-      if (!kIsWeb || _web == null) {
+      if (!_isWeb || _web == null) {
         return const Left(
           ServerFailure(
             'Web GitHub sign-in is not available on this platform',
           ),
         );
       }
-      final token = await _web.signIn(scopes: scopes);
+      await _store.cacheRememberPreference(rememberMe);
+      final token = await _web!.signIn(scopes: scopes);
+      if (token == kGithubRedirectPendingToken) {
+        return const Right(GithubWebSignInResult.redirecting());
+      }
       await _store.write(
         token,
         rememberMe: rememberMe,
         ttl: _resolveTtl(remember: rememberMe, override: ttl),
       );
-      return Right(token);
+      await _store.clearRememberPreference();
+      return Right(GithubWebSignInResult.authorized(token));
     } on DioException catch (e, s) {
       AppLogger.error(
         'web signIn dio failed',
@@ -140,6 +149,7 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
         stackTrace: s,
         area: 'github.auth',
       );
+      await _store.clearRememberPreference();
       return Left(ServerFailure(e.message ?? 'Request failed'));
     } on fb.FirebaseAuthException catch (e, s) {
       // Keep message concise for UI
@@ -149,6 +159,7 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
         stackTrace: s,
         area: 'github.auth',
       );
+      await _store.clearRememberPreference();
       return Left(AuthFailure(e.message ?? e.code));
     } catch (e, s) {
       AppLogger.error(
@@ -157,7 +168,53 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
         stackTrace: s,
         area: 'github.auth',
       );
+      await _store.clearRememberPreference();
       return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Option<String>> completePendingWebSignIn({Duration? ttl}) async {
+    if (!_isWeb || _web == null) {
+      return const None();
+    }
+    try {
+      final token = await _web!.consumeRedirectResult();
+      if (token == null || token.isEmpty) {
+        return const None();
+      }
+      final rememberPref = await _store.readRememberPreference() ?? false;
+      await _store.write(
+        token,
+        rememberMe: rememberPref,
+        ttl: _resolveTtl(remember: rememberPref, override: ttl),
+      );
+      await _store.clearRememberPreference();
+      return Some(token);
+    } on fb.FirebaseAuthException catch (e, s) {
+      AppLogger.error(
+        'web redirect completion failed',
+        error: e,
+        stackTrace: s,
+        area: 'github.auth',
+      );
+      return const None();
+    } on DioException catch (e, s) {
+      AppLogger.error(
+        'web redirect dio failed',
+        error: e,
+        stackTrace: s,
+        area: 'github.auth',
+      );
+      return const None();
+    } catch (e, s) {
+      AppLogger.error(
+        'web redirect completion unexpected failure',
+        error: e,
+        stackTrace: s,
+        area: 'github.auth',
+      );
+      return const None();
     }
   }
 
@@ -178,5 +235,7 @@ class GithubAuthRepositoryImpl implements GithubAuthRepository {
   Future<String?> readToken() => _store.read();
 
   @override
-  Future<void> deleteToken() => _store.clear();
+  Future<void> deleteToken() async {
+    await _store.clear();
+  }
 }

--- a/lib/features/github/domain/entities/github_web_sign_in_result.dart
+++ b/lib/features/github/domain/entities/github_web_sign_in_result.dart
@@ -1,0 +1,15 @@
+class GithubWebSignInResult {
+  const GithubWebSignInResult._({
+    required this.redirectInProgress,
+    this.accessToken,
+  });
+
+  factory GithubWebSignInResult.authorized(String token) =>
+      GithubWebSignInResult._(accessToken: token, redirectInProgress: false);
+
+  const GithubWebSignInResult.redirecting()
+      : this._(redirectInProgress: true, accessToken: null);
+
+  final bool redirectInProgress;
+  final String? accessToken;
+}

--- a/lib/features/github/domain/repositories/github_auth_repository.dart
+++ b/lib/features/github/domain/repositories/github_auth_repository.dart
@@ -1,5 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:devhub_gpt/core/errors/failures.dart';
+import 'package:devhub_gpt/features/github/domain/entities/github_web_sign_in_result.dart';
 import 'package:devhub_gpt/features/github/domain/entities/oauth.dart';
 
 abstract class GithubAuthRepository {
@@ -15,11 +16,13 @@ abstract class GithubAuthRepository {
   });
 
   // Web-only: Sign in via Firebase GitHub provider and return access token
-  Future<Either<Failure, String>> signInWithWeb({
+  Future<Either<Failure, GithubWebSignInResult>> signInWithWeb({
     List<String> scopes = const ['repo', 'read:user'],
     required bool rememberMe,
     Duration? ttl,
   });
+
+  Future<Option<String>> completePendingWebSignIn({Duration? ttl});
 
   Future<void> saveToken(
     String token, {

--- a/lib/features/github/presentation/providers/github_providers.dart
+++ b/lib/features/github/presentation/providers/github_providers.dart
@@ -109,8 +109,8 @@ final githubOAuthDataSourceProvider =
 });
 
 final githubWebOAuthDataSourceProvider =
-    Provider<GithubWebOAuthDataSource>((ref) {
-  return const GithubWebOAuthDataSource();
+    Provider<GithubWebOAuthDataSourceBase>((ref) {
+  return GithubWebOAuthDataSource();
 });
 
 final githubAuthRepositoryProvider = Provider<GithubAuthRepository>((ref) {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -246,6 +246,15 @@ class _GithubSignInBlock extends ConsumerWidget {
       );
     }
 
+    if (state is GithubAuthRedirecting) {
+      return const ListTile(
+        leading: AppProgressIndicator(size: 20),
+        title: Text('Відкриваємо GitHub у новій вкладці...'),
+        subtitle:
+            Text('Якщо вікно не зʼявилось, дозвольте pop-up для цього сайту.'),
+      );
+    }
+
     if (state is GithubAuthCodeReady) {
       final s = state as GithubAuthCodeReady;
       return Column(

--- a/lib/shared/network/token_store.dart
+++ b/lib/shared/network/token_store.dart
@@ -7,6 +7,7 @@ const _kLegacyTokenKey = 'github_token';
 const Duration _kEphemeralTtl = Duration(hours: 12);
 const Duration _kRememberedTtl = Duration(days: 30);
 const Duration _kLegacyMigrationTtl = Duration(hours: 24);
+const String _kRememberPreferenceKey = 'github_token_remember_pref';
 
 class TokenPayload {
   const TokenPayload({
@@ -94,6 +95,11 @@ class TokenStore {
     } catch (_) {
       // Ignore missing plugin / platform errors in tests.
     }
+    try {
+      await _storage.delete(key: _kRememberPreferenceKey);
+    } catch (_) {
+      // Ignore storage backend errors in tests.
+    }
   }
 
   Future<void> clear() async {
@@ -108,10 +114,46 @@ class TokenStore {
     } catch (_) {
       // Ignore storage backend errors in tests.
     }
+    try {
+      await _storage.delete(key: _kRememberPreferenceKey);
+    } catch (_) {
+      // Ignore storage backend errors in tests.
+    }
   }
 
   Duration defaultTtl({required bool rememberMe}) =>
       rememberMe ? _kRememberedTtl : _kEphemeralTtl;
+
+  Future<void> cacheRememberPreference(bool remember) async {
+    try {
+      await _storage.write(
+        key: _kRememberPreferenceKey,
+        value: remember ? 'true' : 'false',
+      );
+    } catch (_) {
+      // Ignore storage backend errors in tests.
+    }
+  }
+
+  Future<bool?> readRememberPreference() async {
+    try {
+      final value = await _storage.read(key: _kRememberPreferenceKey);
+      if (value == null) return null;
+      if (value == 'true') return true;
+      if (value == 'false') return false;
+    } catch (_) {
+      // Ignore storage backend errors in tests.
+    }
+    return null;
+  }
+
+  Future<void> clearRememberPreference() async {
+    try {
+      await _storage.delete(key: _kRememberPreferenceKey);
+    } catch (_) {
+      // Ignore storage backend errors in tests.
+    }
+  }
 
   Future<TokenPayload?> _loadFromStorage() async {
     final raw = await _storage.read(key: _kPayloadKey);

--- a/test/unit/features/github/data/datasources/github_web_oauth_data_source_test.dart
+++ b/test/unit/features/github/data/datasources/github_web_oauth_data_source_test.dart
@@ -1,0 +1,20 @@
+import 'package:devhub_gpt/features/github/data/datasources/github_web_oauth_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('shouldIgnoreRedirectError', () {
+    test('returns true for no-current-user', () {
+      expect(shouldIgnoreRedirectError('no-current-user'), isTrue);
+    });
+
+    test('returns true for no-auth-event variants', () {
+      expect(shouldIgnoreRedirectError('no-auth-event'), isTrue);
+      expect(shouldIgnoreRedirectError('auth/no-auth-event'), isTrue);
+    });
+
+    test('returns false for other errors', () {
+      expect(shouldIgnoreRedirectError('popup-blocked'), isFalse);
+      expect(shouldIgnoreRedirectError(''), isFalse);
+    });
+  });
+}

--- a/test/unit/features/github/data/repositories/github_auth_repository_impl_test.dart
+++ b/test/unit/features/github/data/repositories/github_auth_repository_impl_test.dart
@@ -1,0 +1,154 @@
+import 'package:dartz/dartz.dart';
+import 'package:devhub_gpt/features/github/data/datasources/github_oauth_remote_data_source.dart';
+import 'package:devhub_gpt/features/github/data/datasources/github_web_oauth_data_source.dart';
+import 'package:devhub_gpt/features/github/data/repositories/github_auth_repository_impl.dart';
+import 'package:devhub_gpt/features/github/domain/entities/github_web_sign_in_result.dart';
+import 'package:devhub_gpt/shared/network/token_store.dart';
+import 'package:dio/dio.dart';
+import 'package:firebase_auth/firebase_auth.dart' as fb;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _StubSecureStorage extends FlutterSecureStorage {
+  final Map<String, String?> _store = {};
+
+  @override
+  Future<void> write({
+    required String key,
+    String? value,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WindowsOptions? wOptions,
+    MacOsOptions? mOptions,
+    WebOptions? webOptions,
+  }) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WindowsOptions? wOptions,
+    MacOsOptions? mOptions,
+    WebOptions? webOptions,
+  }) async {
+    return _store[key];
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    IOSOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WindowsOptions? wOptions,
+    MacOsOptions? mOptions,
+    WebOptions? webOptions,
+  }) async {
+    _store.remove(key);
+  }
+}
+
+class _FakeGithubWebOAuthDataSource implements GithubWebOAuthDataSourceBase {
+  _FakeGithubWebOAuthDataSource(
+      {this.signInValue = 'token', this.redirectValue});
+
+  String signInValue;
+  String? redirectValue;
+  fb.FirebaseAuthException? signInError;
+  fb.FirebaseAuthException? redirectError;
+  int signInCalls = 0;
+  int consumeCalls = 0;
+
+  @override
+  Future<String> signIn(
+      {List<String> scopes = const ['repo', 'read:user']}) async {
+    signInCalls++;
+    if (signInError != null) throw signInError!;
+    return signInValue;
+  }
+
+  @override
+  Future<String?> consumeRedirectResult() async {
+    consumeCalls++;
+    if (redirectError != null) throw redirectError!;
+    return redirectValue;
+  }
+}
+
+void main() {
+  late GithubAuthRepositoryImpl repository;
+  late _FakeGithubWebOAuthDataSource web;
+  late TokenStore store;
+
+  setUp(() {
+    web = _FakeGithubWebOAuthDataSource();
+    store = TokenStore(_StubSecureStorage());
+    repository = GithubAuthRepositoryImpl(
+      GithubOAuthRemoteDataSource(Dio()),
+      store,
+      web: web,
+      isWebOverride: true,
+    );
+  });
+
+  test('signInWithWeb stores token and clears remember preference', () async {
+    final result = await repository.signInWithWeb(rememberMe: true);
+
+    expect(result.isRight(), isTrue);
+    final success =
+        result.getOrElse(() => const GithubWebSignInResult.redirecting());
+    expect(success.redirectInProgress, isFalse);
+    expect(success.accessToken, equals('token'));
+
+    final payload = await store.readPayload();
+    expect(payload, isNotNull);
+    expect(payload!.token, equals('token'));
+    expect(payload.rememberMe, isTrue);
+    final pref = await store.readRememberPreference();
+    expect(pref, isNull);
+  });
+
+  test('signInWithWeb returns redirect result when popup blocked', () async {
+    web.signInValue = kGithubRedirectPendingToken;
+    final result = await repository.signInWithWeb(rememberMe: false);
+
+    expect(result.isRight(), isTrue);
+    final success =
+        result.getOrElse(() => const GithubWebSignInResult.redirecting());
+    expect(success.redirectInProgress, isTrue);
+    final payload = await store.readPayload();
+    expect(payload, isNull);
+    final pref = await store.readRememberPreference();
+    expect(pref, isFalse);
+  });
+
+  test('completePendingWebSignIn persists redirect token and clears pref',
+      () async {
+    await store.cacheRememberPreference(true);
+    web.redirectValue = 'redirect-token';
+
+    final option = await repository.completePendingWebSignIn();
+
+    expect(option.isSome(), isTrue);
+    expect(option.getOrElse(() => ''), equals('redirect-token'));
+    final payload = await store.readPayload();
+    expect(payload, isNotNull);
+    expect(payload!.token, equals('redirect-token'));
+    expect(payload.rememberMe, isTrue);
+    final pref = await store.readRememberPreference();
+    expect(pref, isNull);
+  });
+
+  test('completePendingWebSignIn returns None when no redirect data', () async {
+    final option = await repository.completePendingWebSignIn();
+
+    expect(option, const None());
+    final payload = await store.readPayload();
+    expect(payload, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- overhaul the GitHub web OAuth data source to support redirect flows, ignore benign redirect errors, and expose a helper
- expand the auth repository, notifier, providers, and settings UI to handle redirect-in-progress state and remember preferences
- add a GithubWebSignInResult entity plus unit tests covering the web OAuth data source and repository flows

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68cf3e7372f483339301c97df2328692