### PR TITLE
Add CSP and metadata to Flutter web entry page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -18,7 +18,27 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta
+    http-equiv="Content-Security-Policy"
+    content="
+      default-src 'self';
+      base-uri 'self';
+      connect-src 'self' https://api.github.com https://github.com https://*.github.com https://*.githubusercontent.com https://api.example.com http://localhost:* https://localhost:* https://*.ngrok.io;
+      font-src 'self' data:;
+      form-action 'self' https://github.com https://*.github.com;
+      frame-ancestors 'none';
+      frame-src 'self' https://github.com https://*.github.com;
+      img-src 'self' blob: data: https://github.com https://*.githubusercontent.com;
+      manifest-src 'self';
+      media-src 'self';
+      object-src 'none';
+      script-src 'self' 'wasm-unsafe-eval';
+      style-src 'self';
+      worker-src 'self' blob:;
+    ">
+  <meta name="description" content="DevHub GPT web experience with GitHub integration.">
+  <meta name="theme-color" content="#121212">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">


### PR DESCRIPTION
## Summary
- set the web entry point language, viewport metadata, and theme color
- add a strict content security policy that allows required GitHub and local development origins while blocking unwanted sources

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf703174b88333a58111bbd38ab568