### PR TITLE
Add dashboard file uploads and sharing options

### DIFF
--- a/lib/features/commits/data/models/commit_model.dart
+++ b/lib/features/commits/data/models/commit_model.dart
@@ -16,8 +16,7 @@ class CommitModel {
       id: sha,
       message: (commit['message'] as String?)?.trim() ?? '',
       author: (author?['name'] as String?) ?? 'unknown',
-      date:
-          DateTime.tryParse((author?['date'] as String?) ?? '') ??
+      date: DateTime.tryParse((author?['date'] as String?) ?? '') ??
           DateTime.now(),
     );
   }
@@ -27,6 +26,11 @@ class CommitModel {
   final String author;
   final DateTime date;
 
-  CommitInfo toDomain() =>
-      CommitInfo(id: id, message: message, author: author, date: date);
+  CommitInfo toDomain({required String repoFullName}) => CommitInfo(
+        id: id,
+        message: message,
+        author: author,
+        date: date,
+        repoFullName: repoFullName,
+      );
 }

--- a/lib/features/commits/data/repositories/github_commits_repository.dart
+++ b/lib/features/commits/data/repositories/github_commits_repository.dart
@@ -12,8 +12,8 @@ class GithubCommitsRepository implements CommitsRepository {
     this._authHeaders, {
     GithubLocalDao? dao,
     Future<String> Function()? tokenScope,
-  }) : _dao = dao,
-       _tokenScope = tokenScope;
+  })  : _dao = dao,
+        _tokenScope = tokenScope;
 
   final GithubRemoteDataSource _ds;
   final Future<Map<String, String>> Function() _authHeaders;
@@ -56,13 +56,15 @@ class GithubCommitsRepository implements CommitsRepository {
         repo: name,
         perPage: 10,
       );
-      final domain = commits.map((e) => e.toDomain()).toList();
+      final repoFullName = repos.first.fullName;
+      final domain =
+          commits.map((e) => e.toDomain(repoFullName: repoFullName)).toList();
       // Cache
       final dao = _dao;
       final scopeFn = _tokenScope;
       if (dao != null && scopeFn != null) {
         final scope = await scopeFn();
-        await dao.insertCommits(scope, repos.first.fullName, domain);
+        await dao.insertCommits(scope, repoFullName, domain);
       }
       return domain;
     } catch (_) {

--- a/lib/features/commits/data/repositories/mock_commits_repository.dart
+++ b/lib/features/commits/data/repositories/mock_commits_repository.dart
@@ -11,18 +11,21 @@ class MockCommitsRepository implements CommitsRepository {
         message: 'Initial commit',
         author: 'alice',
         date: now.subtract(const Duration(days: 2)),
+        repoFullName: 'example/app',
       ),
       CommitInfo(
         id: 'c2',
         message: 'Add notes feature scaffold',
         author: 'bob',
         date: now.subtract(const Duration(days: 1, hours: 3)),
+        repoFullName: 'example/app',
       ),
       CommitInfo(
         id: 'c3',
         message: 'Fix routing and tests',
         author: 'carol',
         date: now.subtract(const Duration(hours: 10)),
+        repoFullName: 'example/app',
       ),
     ];
   }

--- a/lib/features/commits/domain/entities/commit.dart
+++ b/lib/features/commits/domain/entities/commit.dart
@@ -4,10 +4,30 @@ class CommitInfo {
     required this.message,
     required this.author,
     required this.date,
+    required this.repoFullName,
   });
 
   final String id;
   final String message;
   final String author;
   final DateTime date;
+  final String repoFullName;
+
+  CommitInfo copyWith({
+    String? id,
+    String? message,
+    String? author,
+    DateTime? date,
+    String? repoFullName,
+  }) {
+    return CommitInfo(
+      id: id ?? this.id,
+      message: message ?? this.message,
+      author: author ?? this.author,
+      date: date ?? this.date,
+      repoFullName: repoFullName ?? this.repoFullName,
+    );
+  }
+
+  Uri get webUrl => Uri.parse('https://github.com/$repoFullName/commit/$id');
 }

--- a/lib/features/commits/presentation/pages/commits_page.dart
+++ b/lib/features/commits/presentation/pages/commits_page.dart
@@ -4,6 +4,7 @@ import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
 class CommitsPage extends ConsumerWidget {
   const CommitsPage({super.key});
@@ -95,7 +96,14 @@ class CommitsPage extends ConsumerWidget {
               final c = list[i];
               return ListTile(
                 title: Text(c.message),
-                subtitle: Text('${c.author} • ${c.date.toLocal()}'),
+                subtitle: Text(
+                  '${c.author} • ${c.date.toLocal()} • ${c.repoFullName}',
+                ),
+                trailing: IconButton(
+                  tooltip: 'Поділитися',
+                  icon: const Icon(Icons.share_outlined),
+                  onPressed: () => Share.shareUri(c.webUrl),
+                ),
               );
             },
           );

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,6 +1,7 @@
 import 'package:devhub_gpt/core/router/app_routes.dart';
 import 'package:devhub_gpt/features/auth/presentation/providers/auth_providers.dart';
 import 'package:devhub_gpt/features/dashboard/presentation/widgets/commit_line_chart.dart';
+import 'package:devhub_gpt/features/files/presentation/widgets/file_upload_card.dart';
 import 'package:devhub_gpt/features/github/presentation/providers/github_providers.dart';
 import 'package:devhub_gpt/features/github/presentation/widgets/github_user_badge.dart';
 import 'package:devhub_gpt/features/notes/presentation/providers/notes_providers.dart';
@@ -53,8 +54,7 @@ class DashboardPage extends ConsumerWidget {
               return const _AuthCta();
             }
 
-            final stillLoading =
-                notesAsync.isLoading ||
+            final stillLoading = notesAsync.isLoading ||
                 commitsAsync.isLoading ||
                 reposAsync.isLoading;
 
@@ -65,6 +65,8 @@ class DashboardPage extends ConsumerWidget {
                     padding: EdgeInsets.symmetric(vertical: 12),
                     child: Text('Оновлюємо дані…'),
                   ),
+                const FileUploadCard(),
+                const SizedBox(height: 12),
                 // Move the commit activity chart to the top area of the dashboard
                 const CommitActivityCard(),
                 const SizedBox(height: 12),
@@ -308,13 +310,12 @@ class _CommitsPanel extends StatelessWidget {
           children: [
             for (final c in items)
               Tooltip(
-                message:
-                    (StringBuffer()
-                          ..writeln(c.message)
-                          ..writeln('Author: ${c.author}')
-                          ..writeln('Date: ${c.date.toLocal()}')
-                          ..writeln('SHA: ${c.id}'))
-                        .toString(),
+                message: (StringBuffer()
+                      ..writeln(c.message)
+                      ..writeln('Author: ${c.author}')
+                      ..writeln('Date: ${c.date.toLocal()}')
+                      ..writeln('SHA: ${c.id}'))
+                    .toString(),
                 waitDuration: const Duration(milliseconds: 200),
                 child: InkWell(
                   onTap: () => const CommitsRoute().go(context),

--- a/lib/features/files/domain/entities/uploaded_file.dart
+++ b/lib/features/files/domain/entities/uploaded_file.dart
@@ -1,0 +1,43 @@
+import 'dart:typed_data';
+
+enum UploadStatus { preparing, uploading, completed, failed }
+
+class UploadedFile {
+  UploadedFile({
+    required this.id,
+    required this.name,
+    required this.size,
+    required this.progress,
+    required this.status,
+    this.errorMessage,
+    this.bytes,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  final String id;
+  final String name;
+  final int size;
+  final double progress;
+  final UploadStatus status;
+  final String? errorMessage;
+  final Uint8List? bytes;
+  final DateTime createdAt;
+
+  UploadedFile copyWith({
+    double? progress,
+    UploadStatus? status,
+    String? errorMessage,
+    Uint8List? bytes,
+  }) {
+    return UploadedFile(
+      id: id,
+      name: name,
+      size: size,
+      progress: progress ?? this.progress,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+      bytes: bytes ?? this.bytes,
+      createdAt: createdAt,
+    );
+  }
+}

--- a/lib/features/files/presentation/providers/file_upload_providers.dart
+++ b/lib/features/files/presentation/providers/file_upload_providers.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:devhub_gpt/features/files/domain/entities/uploaded_file.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+
+final fileUploadControllerProvider =
+    StateNotifierProvider<FileUploadNotifier, List<UploadedFile>>((ref) {
+  return FileUploadNotifier();
+});
+
+final fileUploadPanelExpandedProvider = StateProvider<bool>((ref) => false);
+
+class FileUploadNotifier extends StateNotifier<List<UploadedFile>> {
+  FileUploadNotifier() : super(const <UploadedFile>[]);
+
+  Future<void> pickAndUpload() async {
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: true,
+      withData: kIsWeb,
+      withReadStream: true,
+    );
+    if (result == null) return;
+
+    for (final file in result.files) {
+      unawaited(_startUpload(file));
+    }
+  }
+
+  Future<void> _startUpload(PlatformFile file) async {
+    final id = '${DateTime.now().microsecondsSinceEpoch}-${file.name}';
+    state = [
+      ...state,
+      UploadedFile(
+        id: id,
+        name: file.name,
+        size: file.size,
+        progress: 0,
+        status: UploadStatus.preparing,
+      ),
+    ];
+
+    try {
+      final stream = await _resolveStream(file);
+      if (stream == null) {
+        _update(id, (prev) {
+          return prev.copyWith(
+            status: UploadStatus.failed,
+            errorMessage: 'Не вдалося прочитати файл',
+          );
+        });
+        return;
+      }
+
+      int processed = 0;
+      final builder = BytesBuilder();
+      final total = file.size;
+      _update(id, (prev) => prev.copyWith(status: UploadStatus.uploading));
+
+      await for (final chunk in stream) {
+        processed += chunk.length;
+        builder.add(chunk);
+        final baseProgress = total > 0
+            ? processed / total
+            : processed > 0
+                ? 1.0
+                : 0.0;
+        final normalized = baseProgress.clamp(0.0, 1.0).toDouble();
+        _update(id, (prev) => prev.copyWith(progress: normalized));
+      }
+
+      _update(
+        id,
+        (prev) => prev.copyWith(
+          progress: 1,
+          status: UploadStatus.completed,
+          bytes: builder.takeBytes(),
+        ),
+      );
+    } catch (e) {
+      _update(id, (prev) {
+        return prev.copyWith(
+          status: UploadStatus.failed,
+          errorMessage: e.toString(),
+        );
+      });
+    }
+  }
+
+  Future<Stream<List<int>>?> _resolveStream(PlatformFile file) async {
+    if (file.readStream != null) {
+      return file.readStream;
+    }
+    final bytes = file.bytes;
+    if (bytes != null) {
+      return _streamFromBytes(bytes);
+    }
+    return null;
+  }
+
+  Stream<List<int>> _streamFromBytes(Uint8List data) async* {
+    if (data.isEmpty) {
+      yield data;
+      return;
+    }
+    const chunkSize = 64 * 1024;
+    var offset = 0;
+    while (offset < data.length) {
+      final end = math.min(offset + chunkSize, data.length);
+      yield data.sublist(offset, end);
+      offset = end;
+      // Allow UI to paint progress.
+      await Future<void>.delayed(const Duration(milliseconds: 16));
+    }
+  }
+
+  void _update(String id, UploadedFile Function(UploadedFile) transform) {
+    state = [
+      for (final item in state)
+        if (item.id == id) transform(item) else item,
+    ];
+  }
+}

--- a/lib/features/files/presentation/widgets/file_upload_card.dart
+++ b/lib/features/files/presentation/widgets/file_upload_card.dart
@@ -1,0 +1,200 @@
+import 'package:devhub_gpt/features/files/domain/entities/uploaded_file.dart';
+import 'package:devhub_gpt/features/files/presentation/providers/file_upload_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class FileUploadCard extends ConsumerWidget {
+  const FileUploadCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final expanded = ref.watch(fileUploadPanelExpandedProvider);
+    final uploads = ref.watch(fileUploadControllerProvider);
+    final scheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 20, 16, 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.folder_open, color: scheme.primary),
+                const SizedBox(width: 8),
+                const Text(
+                  'Завантаження файлів',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                ),
+                const Spacer(),
+                TextButton.icon(
+                  onPressed: () {
+                    ref.read(fileUploadPanelExpandedProvider.notifier).state =
+                        !expanded;
+                  },
+                  icon: Icon(expanded ? Icons.expand_less : Icons.expand_more),
+                  label: Text(expanded ? 'Сховати' : 'Показати'),
+                ),
+              ],
+            ),
+            AnimatedCrossFade(
+              crossFadeState: expanded
+                  ? CrossFadeState.showFirst
+                  : CrossFadeState.showSecond,
+              duration: const Duration(milliseconds: 200),
+              firstChild: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 16),
+                  FilledButton.icon(
+                    onPressed: () => ref
+                        .read(fileUploadControllerProvider.notifier)
+                        .pickAndUpload(),
+                    icon: const Icon(Icons.cloud_upload_outlined),
+                    label: const Text('Обрати файли'),
+                  ),
+                  const SizedBox(height: 16),
+                  if (uploads.isEmpty)
+                    Text(
+                      'Файли ще не додані. Натисніть «Обрати файли», щоб підвантажити їх.',
+                      style: TextStyle(
+                        color: scheme.onSurfaceVariant,
+                      ),
+                    )
+                  else
+                    Column(
+                      children: [
+                        for (final file in uploads)
+                          _UploadTile(
+                            key: ValueKey(file.id),
+                            file: file,
+                          ),
+                      ],
+                    ),
+                ],
+              ),
+              secondChild: const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UploadTile extends StatelessWidget {
+  const _UploadTile({required this.file, super.key});
+
+  final UploadedFile file;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final status = file.status;
+    final statusLabel = switch (status) {
+      UploadStatus.preparing => 'Підготовка…',
+      UploadStatus.uploading => 'Завантаження…',
+      UploadStatus.completed => 'Готово',
+      UploadStatus.failed => 'Помилка',
+    };
+    final percent = (file.progress * 100).clamp(0, 100);
+    final color = switch (status) {
+      UploadStatus.completed => scheme.primary,
+      UploadStatus.failed => scheme.error,
+      _ => scheme.primary,
+    };
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                status == UploadStatus.completed
+                    ? Icons.check_circle_outline
+                    : status == UploadStatus.failed
+                        ? Icons.error_outline
+                        : Icons.insert_drive_file_outlined,
+                color: color,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      file.name,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '${_formatSize(file.size)} • $statusLabel',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: status == UploadStatus.failed
+                            ? scheme.error
+                            : scheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Text(
+                '${percent.toStringAsFixed(0)}%',
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: status == UploadStatus.failed
+                      ? scheme.error
+                      : scheme.onSurface,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: status == UploadStatus.failed
+                  ? file.progress.clamp(0, 1)
+                  : file.progress.clamp(0, 1),
+              color: color,
+              minHeight: 6,
+              backgroundColor: scheme.surfaceContainerHighest,
+            ),
+          ),
+          if (status == UploadStatus.failed && file.errorMessage != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Text(
+                file.errorMessage!,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: scheme.error,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatSize(int bytes) {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  var value = bytes.toDouble();
+  var unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return '${value.toStringAsFixed(value < 10 && unitIndex > 0 ? 1 : 0)} ${units[unitIndex]}';
+}

--- a/lib/features/github/data/datasources/local/github_local_dao.dart
+++ b/lib/features/github/data/datasources/local/github_local_dao.dart
@@ -122,6 +122,7 @@ class GithubLocalDao {
               message: r.message,
               author: r.author ?? 'unknown',
               date: r.date ?? DateTime.now(),
+              repoFullName: r.repoFullName,
             ),
           )
           .toList(),
@@ -180,6 +181,7 @@ class GithubLocalDao {
             message: r.message,
             author: r.author ?? 'unknown',
             date: r.date ?? DateTime.now(),
+            repoFullName: r.repoFullName,
           ),
         )
         .toList();

--- a/lib/features/github/presentation/pages/repositories_page.dart
+++ b/lib/features/github/presentation/pages/repositories_page.dart
@@ -4,6 +4,7 @@ import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:share_plus/share_plus.dart';
 
 class RepositoriesPage extends ConsumerStatefulWidget {
   const RepositoriesPage({super.key});
@@ -100,13 +101,26 @@ class _RepositoriesPageState extends ConsumerState<RepositoriesPage> {
                         trailing: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            const Icon(Icons.star, size: 16),
-                            const SizedBox(width: 4),
-                            Text('${r.stargazersCount}'),
+                            Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Icon(Icons.star, size: 16),
+                                const SizedBox(width: 4),
+                                Text('${r.stargazersCount}'),
+                                const SizedBox(width: 12),
+                                const Icon(Icons.call_split, size: 16),
+                                const SizedBox(width: 4),
+                                Text('${r.forksCount}'),
+                              ],
+                            ),
                             const SizedBox(width: 12),
-                            const Icon(Icons.call_split, size: 16),
-                            const SizedBox(width: 4),
-                            Text('${r.forksCount}'),
+                            IconButton(
+                              tooltip: 'Поділитися',
+                              icon: const Icon(Icons.share_outlined),
+                              onPressed: () => Share.shareUri(
+                                Uri.parse('https://github.com/${r.fullName}'),
+                              ),
+                            ),
                           ],
                         ),
                       );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+2"
   crypto:
     dependency: "direct main"
     description:
@@ -313,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: ab13ae8ef5580a411c458d6207b6774a6c237d77ac37011b13994879f68a8810
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.7"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -424,6 +440,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.30"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -948,6 +972,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   pretty_dio_logger: ^1.4.0
   markdown_widget: ^2.3.2+8
   url_launcher: ^6.3.2
+  file_picker: ^8.1.2
+  share_plus: ^10.0.2
 
   # Local Storage / DB
   drift: ^2.28.2

--- a/test/unit/features/commits/data/repositories/github_commits_repository_test.dart
+++ b/test/unit/features/commits/data/repositories/github_commits_repository_test.dart
@@ -110,12 +110,14 @@ void main() {
         message: 'm1',
         author: 'a',
         date: DateTime(2024, 1, 1),
+        repoFullName: 'u/a',
       ),
       CommitInfo(
         id: 'x2',
         message: 'm2',
         author: 'b',
         date: DateTime(2024, 1, 2),
+        repoFullName: 'u/a',
       ),
     ]);
 

--- a/test/unit/features/github/data/models/commit_model_test.dart
+++ b/test/unit/features/github/data/models/commit_model_test.dart
@@ -11,9 +11,10 @@ void main() {
       },
     };
     final model = CommitModel.fromJson(json);
-    final e = model.toDomain();
+    final e = model.toDomain(repoFullName: 'alice/repo');
     expect(e.id, 'abc123');
     expect(e.message, 'Fix bug');
     expect(e.author, 'alice');
+    expect(e.repoFullName, 'alice/repo');
   });
 }

--- a/test/widget/dashboard_page_test.dart
+++ b/test/widget/dashboard_page_test.dart
@@ -38,6 +38,11 @@ void main() {
 
     await pumpUntilStable(tester);
 
+    await tester.scrollUntilVisible(
+      find.text('Block 3 shortcuts'),
+      200,
+    );
+
     expect(find.text('Block 3 shortcuts'), findsOneWidget);
     expect(find.text('Commit Activity'), findsOneWidget);
     expect(find.text('GitHub Repos'), findsWidgets);

--- a/test/widget/features/dashboard/presentation/dashboard_shortcuts_test.dart
+++ b/test/widget/features/dashboard/presentation/dashboard_shortcuts_test.dart
@@ -21,6 +21,12 @@ void main() {
       ),
     );
     await tester.pump();
+
+    await tester.scrollUntilVisible(
+      find.text('Block 3 shortcuts'),
+      200,
+    );
+
     expect(find.text('Block 3 shortcuts'), findsOneWidget);
     expect(find.byKey(const ValueKey('btnGithubRepos')), findsOneWidget);
     expect(find.byKey(const ValueKey('btnAssistant')), findsOneWidget);

--- a/test/widget/router_deeplink_test.dart
+++ b/test/widget/router_deeplink_test.dart
@@ -77,6 +77,11 @@ void main() {
       GoRouter.of(ctx).go('/auth/register');
       await pumpUntilStable(tester);
 
+      await tester.scrollUntilVisible(
+        find.text('Block 3 shortcuts'),
+        200,
+      );
+
       expect(find.text('Block 3 shortcuts'), findsOneWidget);
       expect(find.text('Commit Activity'), findsOneWidget);
     },

--- a/test/widget/router_redirect_test.dart
+++ b/test/widget/router_redirect_test.dart
@@ -41,6 +41,11 @@ void main() {
 
     await pumpUntilStable(tester);
 
+    await tester.scrollUntilVisible(
+      find.text('Block 3 shortcuts'),
+      200,
+    );
+
     // Dashboard content should be present
     expect(find.text('Block 3 shortcuts'), findsOneWidget);
     expect(find.text('Commit Activity'), findsOneWidget);

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -19,6 +20,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   flutter_secure_storage_windows
+  share_plus
   sqlite3_flutter_libs
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary
- add a web-ready file upload flow with progress tracking and a collapsible card on the dashboard
- enable sharing GitHub repositories and commits via new share buttons and enriched commit metadata
- update router and dashboard widget tests to scroll to the shortcuts section before asserting

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d58209b3248333a210028e94ff0fda