### PR TITLE
Guard Firebase usage before initialization

### DIFF
--- a/lib/core/constants/firebase_flags.dart
+++ b/lib/core/constants/firebase_flags.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 
 /// Flags that toggle Firebase services without removing dependencies.
@@ -11,14 +12,18 @@ const bool kUseFirebase = bool.fromEnvironment(
 
 /// Dedicated flag for Firebase Authentication usage.
 /// Falls back to [kUseFirebase] when specific override is not provided.
-const bool kUseFirebaseAuth =
-    bool.fromEnvironment('USE_FIREBASE_AUTH', defaultValue: true) &&
+const bool kUseFirebaseAuth = bool.fromEnvironment(
+      'USE_FIREBASE_AUTH',
+      defaultValue: true,
+    ) &&
     kUseFirebase;
 
 /// Dedicated flag for Firebase Cloud Messaging.
 /// Disabled automatically for web tests when Firebase is disabled.
-const bool kUseFirebaseMessaging =
-    bool.fromEnvironment('USE_FIREBASE_MESSAGING', defaultValue: true) &&
+const bool kUseFirebaseMessaging = bool.fromEnvironment(
+      'USE_FIREBASE_MESSAGING',
+      defaultValue: true,
+    ) &&
     kUseFirebase;
 
 const bool kInFlutterTest = bool.fromEnvironment(
@@ -42,3 +47,10 @@ bool get isFirebaseMessagingSupportedPlatform {
       return false;
   }
 }
+
+/// Returns `true` when a default Firebase app has already been configured.
+///
+/// Some services (Auth, Messaging) synchronously access `Firebase.app()`
+/// which throws when initialization has not completed yet (e.g. when running
+/// with `--start-paused`).
+bool get isFirebaseInitialized => Firebase.apps.isNotEmpty;


### PR DESCRIPTION
## Summary
- add a shared `isFirebaseInitialized` helper to detect when Firebase has been bootstrapped
- skip Firebase-auth and messaging provider setup until initialization succeeds, logging a fallback message when we return to no-op implementations
- enforce initialization checks when deriving repositories to avoid app/no-app exceptions when running with `--start-paused`

## Testing
- flutter analyze
- flutter run -d web-server --start-paused --web-port 7357 --web-hostname 0.0.0.0


------
https://chatgpt.com/codex/tasks/task_e_68d5dcbf14ac8333b52b91301dccc66b