### PR TITLE
Add remote config welcome banner widget

### DIFF
--- a/lib/core/constants/firebase_flags.dart
+++ b/lib/core/constants/firebase_flags.dart
@@ -26,6 +26,12 @@ const bool kUseFirebaseMessaging = bool.fromEnvironment(
     ) &&
     kUseFirebase;
 
+const bool kUseFirebaseRemoteConfig = bool.fromEnvironment(
+      'USE_FIREBASE_REMOTE_CONFIG',
+      defaultValue: true,
+    ) &&
+    kUseFirebase;
+
 const bool kInFlutterTest = bool.fromEnvironment(
   'FLUTTER_TEST',
   defaultValue: false,

--- a/lib/features/shell/presentation/main_shell.dart
+++ b/lib/features/shell/presentation/main_shell.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:devhub_gpt/features/github/presentation/providers/github_providers.dart';
 import 'package:devhub_gpt/features/shell/presentation/widgets/app_side_nav.dart';
+import 'package:devhub_gpt/shared/config/remote_config/presentation/widgets/remote_config_welcome_banner.dart';
 import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
 import 'package:devhub_gpt/shared/providers/secure_storage_provider.dart';
 import 'package:flutter/material.dart';
@@ -39,11 +40,10 @@ class _MainShellState extends ConsumerState<MainShell>
           String? token = value?.trim();
           if (token == null || token.isEmpty) {
             try {
-              token =
-                  (await ref
-                          .read(secureStorageProvider)
-                          .read(key: 'github_token'))
-                      ?.trim();
+              token = (await ref
+                      .read(secureStorageProvider)
+                      .read(key: 'github_token'))
+                  ?.trim();
             } catch (_) {
               token = null;
             }
@@ -106,7 +106,13 @@ class _MainShellState extends ConsumerState<MainShell>
           Expanded(
             child: Padding(
               padding: const EdgeInsets.all(16),
-              child: widget.child,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const RemoteConfigWelcomeBanner(),
+                  Expanded(child: widget.child),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/shared/config/remote_config/application/remote_config_controller.dart
+++ b/lib/shared/config/remote_config/application/remote_config_controller.dart
@@ -1,0 +1,141 @@
+import 'dart:developer';
+
+import 'package:devhub_gpt/shared/config/remote_config/application/remote_config_state.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/repositories/remote_config_repository.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_defaults.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_keys.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RemoteConfigController extends AsyncNotifier<RemoteConfigState> {
+  bool _initialized = false;
+
+  RemoteConfigRepository get _repository =>
+      ref.read(remoteConfigRepositoryProvider);
+
+  Map<String, Object> get _defaults => ref.read(remoteConfigDefaultsProvider);
+
+  RemoteConfigSettings get _settings => const RemoteConfigSettings();
+
+  @override
+  Future<RemoteConfigState> build() {
+    return _initialize(forceRefresh: false);
+  }
+
+  Future<RemoteConfigState> _initialize({required bool forceRefresh}) async {
+    final result = await _repository.initialize(
+      settings: _settings,
+      defaults: _defaults,
+      forceRefresh: forceRefresh,
+    );
+    return result.fold((failure) {
+      log('Remote Config initialization failed: ${failure.message}');
+      throw failure;
+    }, (metadata) {
+      _initialized = true;
+      return RemoteConfigState(
+        metadata: metadata,
+        flags: _buildFeatureFlags(),
+      );
+    });
+  }
+
+  Future<void> refresh({bool force = false}) async {
+    if (!_initialized) {
+      state = const AsyncValue.loading();
+      state = await AsyncValue.guard(
+        () => _initialize(forceRefresh: force),
+      );
+      return;
+    }
+
+    state = const AsyncValue.loading();
+    final result = await _repository.refresh(force: force);
+    state = result.fold((failure) {
+      log('Remote Config refresh failed: ${failure.message}');
+      return AsyncValue.error(failure, StackTrace.current);
+    }, (metadata) {
+      return AsyncValue.data(
+        RemoteConfigState(
+          metadata: metadata,
+          flags: _buildFeatureFlags(),
+        ),
+      );
+    });
+  }
+
+  RemoteConfigFeatureFlags _buildFeatureFlags() {
+    final bool welcomeBannerEnabled = _repository
+        .getBool(
+          RemoteConfigKeys.welcomeBannerEnabled,
+          fallback: RemoteConfigDefaults.welcomeBannerEnabled,
+        )
+        .value;
+    final int markdownMaxLines = _repository
+        .getInt(
+          RemoteConfigKeys.markdownMaxLines,
+          fallback: RemoteConfigDefaults.markdownMaxLines,
+        )
+        .value;
+    final List<String> supportedLocales = _repository
+        .getStringList(
+          RemoteConfigKeys.supportedLocales,
+          fallback: RemoteConfigDefaults.supportedLocalesList,
+        )
+        .value;
+    final String themeModeRaw = _repository
+        .getString(
+          RemoteConfigKeys.appThemeMode,
+          fallback: RemoteConfigDefaults.appThemeMode,
+        )
+        .value;
+    final String welcomeMessage = _repository
+        .getString(
+          RemoteConfigKeys.welcomeMessage,
+          fallback: RemoteConfigDefaults.welcomeMessage,
+        )
+        .value;
+
+    return RemoteConfigFeatureFlags(
+      welcomeBannerEnabled: welcomeBannerEnabled,
+      markdownMaxLines: markdownMaxLines,
+      supportedLocales: supportedLocales,
+      forcedThemeMode: _mapThemeMode(themeModeRaw),
+      welcomeMessage: welcomeMessage,
+    );
+  }
+
+  ThemeMode? _mapThemeMode(String rawValue) {
+    switch (rawValue.toLowerCase()) {
+      case 'system':
+        return ThemeMode.system;
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      case '':
+      case 'none':
+        return null;
+      default:
+        return null;
+    }
+  }
+}
+
+final remoteConfigControllerProvider =
+    AsyncNotifierProvider<RemoteConfigController, RemoteConfigState>(
+  RemoteConfigController.new,
+);
+
+final remoteConfigFeatureFlagsProvider =
+    Provider<RemoteConfigFeatureFlags?>((ref) {
+  final AsyncValue<RemoteConfigState> state =
+      ref.watch(remoteConfigControllerProvider);
+  return state.maybeWhen(
+    data: (RemoteConfigState value) => value.flags,
+    orElse: () => null,
+  );
+});

--- a/lib/shared/config/remote_config/application/remote_config_state.dart
+++ b/lib/shared/config/remote_config/application/remote_config_state.dart
@@ -1,0 +1,22 @@
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+
+class RemoteConfigState {
+  const RemoteConfigState({
+    required this.metadata,
+    required this.flags,
+  });
+
+  final RemoteConfigMetadata metadata;
+  final RemoteConfigFeatureFlags flags;
+
+  RemoteConfigState copyWith({
+    RemoteConfigMetadata? metadata,
+    RemoteConfigFeatureFlags? flags,
+  }) {
+    return RemoteConfigState(
+      metadata: metadata ?? this.metadata,
+      flags: flags ?? this.flags,
+    );
+  }
+}

--- a/lib/shared/config/remote_config/data/datasources/firebase_remote_config_data_source.dart
+++ b/lib/shared/config/remote_config/data/datasources/firebase_remote_config_data_source.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_metadata_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_value_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart'
+    as firebase_remote_config;
+
+class FirebaseRemoteConfigDataSource implements RemoteConfigDataSource {
+  FirebaseRemoteConfigDataSource(
+    this._remoteConfig,
+  );
+
+  final firebase_remote_config.FirebaseRemoteConfig _remoteConfig;
+  RemoteConfigSettings? _settings;
+  bool _configured = false;
+  Completer<void>? _initializingCompleter;
+
+  @override
+  Future<void> ensureInitialized({
+    required RemoteConfigSettings settings,
+    required Map<String, Object> defaultValues,
+  }) async {
+    _settings = settings;
+    _initializingCompleter ??= Completer<void>();
+    if (!_configured) {
+      await _remoteConfig.setConfigSettings(
+        firebase_remote_config.RemoteConfigSettings(
+          fetchTimeout: settings.fetchTimeout,
+          minimumFetchInterval: settings.minimumFetchInterval,
+        ),
+      );
+      if (defaultValues.isNotEmpty) {
+        await _remoteConfig.setDefaults(defaultValues);
+      }
+      await _remoteConfig.ensureInitialized();
+      _configured = true;
+      _initializingCompleter?.complete();
+    } else {
+      await _remoteConfig.setConfigSettings(
+        firebase_remote_config.RemoteConfigSettings(
+          fetchTimeout: settings.fetchTimeout,
+          minimumFetchInterval: settings.minimumFetchInterval,
+        ),
+      );
+      if (defaultValues.isNotEmpty) {
+        await _remoteConfig.setDefaults(defaultValues);
+      }
+      _initializingCompleter?.complete();
+    }
+  }
+
+  @override
+  Future<bool> fetchAndActivate({bool force = false}) async {
+    await _initializingCompleter?.future;
+    final RemoteConfigSettings? settings = _settings;
+    if (force && settings != null) {
+      final firebaseSettings = firebase_remote_config.RemoteConfigSettings(
+        fetchTimeout: settings.fetchTimeout,
+        minimumFetchInterval: Duration.zero,
+      );
+      await _remoteConfig.setConfigSettings(firebaseSettings);
+      try {
+        return await _remoteConfig.fetchAndActivate();
+      } finally {
+        await _remoteConfig.setConfigSettings(
+          firebase_remote_config.RemoteConfigSettings(
+            fetchTimeout: settings.fetchTimeout,
+            minimumFetchInterval: settings.minimumFetchInterval,
+          ),
+        );
+      }
+    }
+    return _remoteConfig.fetchAndActivate();
+  }
+
+  @override
+  RemoteConfigMetadataModel getMetadata() {
+    return RemoteConfigMetadataModel.fromFirebase(_remoteConfig);
+  }
+
+  @override
+  RemoteConfigValueModel<bool> getBool(String key, {required bool fallback}) {
+    final firebaseValue = _remoteConfig.getValue(key);
+    return RemoteConfigValueModel<bool>.fromFirebase(
+      key: key,
+      remoteValue: firebaseValue,
+      parser: (value) => value.asBool(),
+      fallback: fallback,
+      lastFetchTime: _remoteConfig.lastFetchTime,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<double> getDouble(
+    String key, {
+    required double fallback,
+  }) {
+    final firebaseValue = _remoteConfig.getValue(key);
+    return RemoteConfigValueModel<double>.fromFirebase(
+      key: key,
+      remoteValue: firebaseValue,
+      parser: (value) => value.asDouble(),
+      fallback: fallback,
+      lastFetchTime: _remoteConfig.lastFetchTime,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<int> getInt(String key, {required int fallback}) {
+    final firebaseValue = _remoteConfig.getValue(key);
+    return RemoteConfigValueModel<int>.fromFirebase(
+      key: key,
+      remoteValue: firebaseValue,
+      parser: (value) => value.asInt(),
+      fallback: fallback,
+      lastFetchTime: _remoteConfig.lastFetchTime,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<String> getString(
+    String key, {
+    required String fallback,
+  }) {
+    final firebaseValue = _remoteConfig.getValue(key);
+    return RemoteConfigValueModel<String>.fromFirebase(
+      key: key,
+      remoteValue: firebaseValue,
+      parser: (value) => value.asString(),
+      fallback: fallback,
+      lastFetchTime: _remoteConfig.lastFetchTime,
+    );
+  }
+}

--- a/lib/shared/config/remote_config/data/datasources/in_memory_remote_config_data_source.dart
+++ b/lib/shared/config/remote_config/data/datasources/in_memory_remote_config_data_source.dart
@@ -1,0 +1,165 @@
+import 'dart:convert';
+
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_metadata_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_value_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+
+class InMemoryRemoteConfigDataSource implements RemoteConfigDataSource {
+  InMemoryRemoteConfigDataSource({
+    Map<String, Object?>? remoteOverrides,
+  }) : _remoteOverrides = Map<String, Object?>.from(
+          remoteOverrides ?? <String, Object?>{},
+        );
+
+  final Map<String, Object?> _remoteOverrides;
+  Map<String, Object> _defaults = <String, Object>{};
+  RemoteConfigMetadataModel _metadata = const RemoteConfigMetadataModel(
+    lastFetchStatus: RemoteConfigLastFetchStatus.noFetchYet,
+    lastFetchTime: null,
+  );
+  bool _fetched = false;
+
+  @override
+  Future<void> ensureInitialized({
+    required RemoteConfigSettings settings,
+    required Map<String, Object> defaultValues,
+  }) async {
+    _defaults = Map<String, Object>.from(defaultValues);
+  }
+
+  @override
+  Future<bool> fetchAndActivate({bool force = false}) async {
+    _fetched = true;
+    _metadata = RemoteConfigMetadataModel(
+      lastFetchStatus: RemoteConfigLastFetchStatus.success,
+      lastFetchTime: DateTime.now(),
+    );
+    return true;
+  }
+
+  void setRemoteValue(String key, Object? value) {
+    _remoteOverrides[key] = value;
+  }
+
+  @override
+  RemoteConfigMetadataModel getMetadata() => _metadata;
+
+  @override
+  RemoteConfigValueModel<bool> getBool(String key, {required bool fallback}) {
+    final Object? value = _resolveValue(key);
+    return RemoteConfigValueModel<bool>(
+      key: key,
+      value: value is bool ? value : fallback,
+      source: _sourceFor(key, value),
+      lastFetchTime: _metadata.lastFetchTime,
+      usedFallback: value is! bool,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<double> getDouble(
+    String key, {
+    required double fallback,
+  }) {
+    final Object? value = _resolveValue(key);
+    double resolved;
+    var usedFallback = false;
+    if (value is num) {
+      resolved = value.toDouble();
+    } else if (value is String) {
+      resolved = double.tryParse(value) ?? fallback;
+      usedFallback = double.tryParse(value) == null;
+    } else {
+      resolved = fallback;
+      usedFallback = true;
+    }
+    return RemoteConfigValueModel<double>(
+      key: key,
+      value: resolved,
+      source: _sourceFor(key, value),
+      lastFetchTime: _metadata.lastFetchTime,
+      usedFallback: usedFallback,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<int> getInt(String key, {required int fallback}) {
+    final Object? value = _resolveValue(key);
+    int resolved;
+    var usedFallback = false;
+    if (value is int) {
+      resolved = value;
+    } else if (value is num) {
+      resolved = value.toInt();
+    } else if (value is String) {
+      resolved = int.tryParse(value) ?? fallback;
+      usedFallback = int.tryParse(value) == null;
+    } else {
+      resolved = fallback;
+      usedFallback = true;
+    }
+    return RemoteConfigValueModel<int>(
+      key: key,
+      value: resolved,
+      source: _sourceFor(key, value),
+      lastFetchTime: _metadata.lastFetchTime,
+      usedFallback: usedFallback,
+    );
+  }
+
+  @override
+  RemoteConfigValueModel<String> getString(
+    String key, {
+    required String fallback,
+  }) {
+    final Object? value = _resolveValue(key);
+    if (value is String) {
+      return RemoteConfigValueModel<String>(
+        key: key,
+        value: value,
+        source: _sourceFor(key, value),
+        lastFetchTime: _metadata.lastFetchTime,
+      );
+    }
+    if (value is List || value is Map) {
+      return RemoteConfigValueModel<String>(
+        key: key,
+        value: jsonEncode(value),
+        source: _sourceFor(key, value),
+        lastFetchTime: _metadata.lastFetchTime,
+      );
+    }
+    return RemoteConfigValueModel<String>(
+      key: key,
+      value: fallback,
+      source: value == null
+          ? RemoteConfigValueSource.staticValue
+          : _sourceFor(key, value),
+      lastFetchTime: _metadata.lastFetchTime,
+      usedFallback: true,
+    );
+  }
+
+  Object? _resolveValue(String key) {
+    if (_fetched && _remoteOverrides.containsKey(key)) {
+      return _remoteOverrides[key];
+    }
+    if (_defaults.containsKey(key)) {
+      return _defaults[key];
+    }
+    return null;
+  }
+
+  RemoteConfigValueSource _sourceFor(String key, Object? value) {
+    if (_fetched && _remoteOverrides.containsKey(key)) {
+      return RemoteConfigValueSource.remote;
+    }
+    if (_defaults.containsKey(key)) {
+      return RemoteConfigValueSource.defaultValue;
+    }
+    return RemoteConfigValueSource.staticValue;
+  }
+}

--- a/lib/shared/config/remote_config/data/datasources/remote_config_data_source.dart
+++ b/lib/shared/config/remote_config/data/datasources/remote_config_data_source.dart
@@ -1,0 +1,34 @@
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_metadata_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_value_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+
+abstract class RemoteConfigDataSource {
+  Future<void> ensureInitialized({
+    required RemoteConfigSettings settings,
+    required Map<String, Object> defaultValues,
+  });
+
+  Future<bool> fetchAndActivate({bool force = false});
+
+  RemoteConfigMetadataModel getMetadata();
+
+  RemoteConfigValueModel<bool> getBool(
+    String key, {
+    required bool fallback,
+  });
+
+  RemoteConfigValueModel<int> getInt(
+    String key, {
+    required int fallback,
+  });
+
+  RemoteConfigValueModel<double> getDouble(
+    String key, {
+    required double fallback,
+  });
+
+  RemoteConfigValueModel<String> getString(
+    String key, {
+    required String fallback,
+  });
+}

--- a/lib/shared/config/remote_config/data/models/remote_config_metadata_model.dart
+++ b/lib/shared/config/remote_config/data/models/remote_config_metadata_model.dart
@@ -1,0 +1,34 @@
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart'
+    as firebase_remote_config;
+
+class RemoteConfigMetadataModel extends RemoteConfigMetadata {
+  const RemoteConfigMetadataModel({
+    required super.lastFetchStatus,
+    required super.lastFetchTime,
+  });
+
+  factory RemoteConfigMetadataModel.fromFirebase(
+    firebase_remote_config.FirebaseRemoteConfig remoteConfig,
+  ) {
+    return RemoteConfigMetadataModel(
+      lastFetchStatus: _mapStatus(remoteConfig.lastFetchStatus),
+      lastFetchTime: remoteConfig.lastFetchTime,
+    );
+  }
+
+  static RemoteConfigLastFetchStatus _mapStatus(
+    firebase_remote_config.RemoteConfigFetchStatus status,
+  ) {
+    switch (status) {
+      case firebase_remote_config.RemoteConfigFetchStatus.noFetchYet:
+        return RemoteConfigLastFetchStatus.noFetchYet;
+      case firebase_remote_config.RemoteConfigFetchStatus.success:
+        return RemoteConfigLastFetchStatus.success;
+      case firebase_remote_config.RemoteConfigFetchStatus.failure:
+        return RemoteConfigLastFetchStatus.failure;
+      case firebase_remote_config.RemoteConfigFetchStatus.throttle:
+        return RemoteConfigLastFetchStatus.throttled;
+    }
+  }
+}

--- a/lib/shared/config/remote_config/data/models/remote_config_value_model.dart
+++ b/lib/shared/config/remote_config/data/models/remote_config_value_model.dart
@@ -1,0 +1,57 @@
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart'
+    as firebase_remote_config;
+
+class RemoteConfigValueModel<T> extends RemoteConfigValue<T> {
+  const RemoteConfigValueModel({
+    required super.key,
+    required super.value,
+    required super.source,
+    super.lastFetchTime,
+    super.usedFallback,
+  });
+
+  factory RemoteConfigValueModel.fromFirebase({
+    required String key,
+    required firebase_remote_config.RemoteConfigValue remoteValue,
+    required T Function(firebase_remote_config.RemoteConfigValue) parser,
+    required T fallback,
+    DateTime? lastFetchTime,
+  }) {
+    final RemoteConfigValueSource source = _mapSource(remoteValue.source);
+    var usedFallback = false;
+    T parsedValue;
+    try {
+      parsedValue = parser(remoteValue);
+    } catch (_) {
+      parsedValue = fallback;
+      usedFallback = true;
+    }
+
+    if (source == RemoteConfigValueSource.staticValue) {
+      parsedValue = fallback;
+      usedFallback = true;
+    }
+
+    return RemoteConfigValueModel<T>(
+      key: key,
+      value: parsedValue,
+      source: source,
+      lastFetchTime: lastFetchTime,
+      usedFallback: usedFallback,
+    );
+  }
+
+  static RemoteConfigValueSource _mapSource(
+    firebase_remote_config.ValueSource source,
+  ) {
+    switch (source) {
+      case firebase_remote_config.ValueSource.valueStatic:
+        return RemoteConfigValueSource.staticValue;
+      case firebase_remote_config.ValueSource.valueDefault:
+        return RemoteConfigValueSource.defaultValue;
+      case firebase_remote_config.ValueSource.valueRemote:
+        return RemoteConfigValueSource.remote;
+    }
+  }
+}

--- a/lib/shared/config/remote_config/data/repositories/remote_config_repository_impl.dart
+++ b/lib/shared/config/remote_config/data/repositories/remote_config_repository_impl.dart
@@ -1,0 +1,163 @@
+import 'dart:convert';
+
+import 'package:dartz/dartz.dart';
+import 'package:devhub_gpt/core/errors/failures.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/repositories/remote_config_repository.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/services.dart';
+
+class RemoteConfigRepositoryImpl implements RemoteConfigRepository {
+  RemoteConfigRepositoryImpl(this._remoteDataSource);
+
+  final RemoteConfigDataSource _remoteDataSource;
+  RemoteConfigSettings _settings = const RemoteConfigSettings();
+  Map<String, Object> _defaults = const <String, Object>{};
+  RemoteConfigMetadata? _metadata;
+  bool _initialized = false;
+
+  @override
+  bool get isInitialized => _initialized;
+
+  @override
+  RemoteConfigMetadata? get lastMetadata => _metadata;
+
+  @override
+  Future<Either<Failure, RemoteConfigMetadata>> initialize({
+    RemoteConfigSettings? settings,
+    Map<String, Object> defaults = const <String, Object>{},
+    bool forceRefresh = false,
+  }) async {
+    final RemoteConfigSettings appliedSettings =
+        settings ?? const RemoteConfigSettings();
+    try {
+      _settings = appliedSettings;
+      _defaults = Map<String, Object>.from(defaults);
+      await _remoteDataSource.ensureInitialized(
+        settings: appliedSettings,
+        defaultValues: _defaults,
+      );
+      await _remoteDataSource.fetchAndActivate(force: forceRefresh);
+      _metadata = _remoteDataSource.getMetadata();
+      _initialized = true;
+      return Right(_metadata!);
+    } catch (error) {
+      return Left(_mapError(error));
+    }
+  }
+
+  @override
+  Future<Either<Failure, RemoteConfigMetadata>> refresh({
+    bool force = false,
+  }) async {
+    if (!_initialized) {
+      return Left(
+        const CacheFailure('Remote Config has not been initialized yet'),
+      );
+    }
+    try {
+      await _remoteDataSource.ensureInitialized(
+        settings: _settings,
+        defaultValues: _defaults,
+      );
+      await _remoteDataSource.fetchAndActivate(force: force);
+      _metadata = _remoteDataSource.getMetadata();
+      return Right(_metadata!);
+    } catch (error) {
+      return Left(_mapError(error));
+    }
+  }
+
+  @override
+  RemoteConfigValue<bool> getBool(
+    String key, {
+    bool fallback = false,
+  }) {
+    return _remoteDataSource.getBool(key, fallback: fallback);
+  }
+
+  @override
+  RemoteConfigValue<double> getDouble(
+    String key, {
+    double fallback = 0.0,
+  }) {
+    return _remoteDataSource.getDouble(key, fallback: fallback);
+  }
+
+  @override
+  RemoteConfigValue<int> getInt(
+    String key, {
+    int fallback = 0,
+  }) {
+    return _remoteDataSource.getInt(key, fallback: fallback);
+  }
+
+  @override
+  RemoteConfigValue<String> getString(
+    String key, {
+    String fallback = '',
+  }) {
+    return _remoteDataSource.getString(key, fallback: fallback);
+  }
+
+  @override
+  RemoteConfigValue<List<String>> getStringList(
+    String key, {
+    List<String> fallback = const <String>[],
+    String separator = ',',
+  }) {
+    final RemoteConfigValue<String> rawValue = _remoteDataSource.getString(
+      key,
+      fallback: fallback.join(separator),
+    );
+    final List<String> parsed = _parseStringList(rawValue.value, separator);
+    final bool shouldUseFallback =
+        (rawValue.usedFallback || rawValue.isStatic) && fallback.isNotEmpty;
+    return RemoteConfigValue<List<String>>(
+      key: rawValue.key,
+      value: shouldUseFallback ? fallback : parsed,
+      source: rawValue.source,
+      lastFetchTime: rawValue.lastFetchTime,
+      usedFallback: shouldUseFallback,
+    );
+  }
+
+  List<String> _parseStringList(String raw, String separator) {
+    if (raw.trim().isEmpty) return <String>[];
+    try {
+      final dynamic decoded = jsonDecode(raw);
+      if (decoded is List) {
+        return decoded
+            .map((dynamic e) => e?.toString() ?? '')
+            .where((element) => element.isNotEmpty)
+            .toList(growable: false);
+      }
+    } catch (_) {
+      // Ignore JSON parsing errors; fallback to separator parsing.
+    }
+    return raw
+        .split(separator)
+        .map((String item) => item.trim())
+        .where((String item) => item.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  Failure _mapError(Object error) {
+    if (error is Failure) {
+      return error;
+    }
+    if (error is FirebaseException) {
+      return ServerFailure(error.message ?? error.code);
+    }
+    if (error is PlatformException) {
+      return ServerFailure(error.message ?? error.code);
+    }
+    if (error is MissingPluginException) {
+      return ServerFailure('Firebase Remote Config plugin missing');
+    }
+    return ServerFailure(error.toString());
+  }
+}

--- a/lib/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart
+++ b/lib/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+class RemoteConfigFeatureFlags extends Equatable {
+  const RemoteConfigFeatureFlags({
+    required this.welcomeBannerEnabled,
+    required this.markdownMaxLines,
+    required this.supportedLocales,
+    required this.forcedThemeMode,
+    required this.welcomeMessage,
+  });
+
+  final bool welcomeBannerEnabled;
+  final int markdownMaxLines;
+  final List<String> supportedLocales;
+  final ThemeMode? forcedThemeMode;
+  final String welcomeMessage;
+
+  @override
+  List<Object?> get props => [
+        welcomeBannerEnabled,
+        markdownMaxLines,
+        supportedLocales,
+        forcedThemeMode,
+        welcomeMessage,
+      ];
+
+  RemoteConfigFeatureFlags copyWith({
+    bool? welcomeBannerEnabled,
+    int? markdownMaxLines,
+    List<String>? supportedLocales,
+    ThemeMode? forcedThemeMode,
+    String? welcomeMessage,
+  }) {
+    return RemoteConfigFeatureFlags(
+      welcomeBannerEnabled: welcomeBannerEnabled ?? this.welcomeBannerEnabled,
+      markdownMaxLines: markdownMaxLines ?? this.markdownMaxLines,
+      supportedLocales: supportedLocales ?? this.supportedLocales,
+      forcedThemeMode: forcedThemeMode ?? this.forcedThemeMode,
+      welcomeMessage: welcomeMessage ?? this.welcomeMessage,
+    );
+  }
+}

--- a/lib/shared/config/remote_config/domain/entities/remote_config_metadata.dart
+++ b/lib/shared/config/remote_config/domain/entities/remote_config_metadata.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+enum RemoteConfigLastFetchStatus { noFetchYet, success, failure, throttled }
+
+class RemoteConfigMetadata extends Equatable {
+  const RemoteConfigMetadata({
+    required this.lastFetchStatus,
+    required this.lastFetchTime,
+  });
+
+  final RemoteConfigLastFetchStatus lastFetchStatus;
+  final DateTime? lastFetchTime;
+
+  bool get hasFetchedSuccessfully =>
+      lastFetchStatus == RemoteConfigLastFetchStatus.success;
+
+  @override
+  List<Object?> get props => [lastFetchStatus, lastFetchTime];
+
+  RemoteConfigMetadata copyWith({
+    RemoteConfigLastFetchStatus? lastFetchStatus,
+    DateTime? lastFetchTime,
+  }) {
+    return RemoteConfigMetadata(
+      lastFetchStatus: lastFetchStatus ?? this.lastFetchStatus,
+      lastFetchTime: lastFetchTime ?? this.lastFetchTime,
+    );
+  }
+}

--- a/lib/shared/config/remote_config/domain/entities/remote_config_settings.dart
+++ b/lib/shared/config/remote_config/domain/entities/remote_config_settings.dart
@@ -1,0 +1,24 @@
+import 'package:equatable/equatable.dart';
+
+class RemoteConfigSettings extends Equatable {
+  const RemoteConfigSettings({
+    this.fetchTimeout = const Duration(seconds: 15),
+    this.minimumFetchInterval = const Duration(hours: 1),
+  });
+
+  final Duration fetchTimeout;
+  final Duration minimumFetchInterval;
+
+  RemoteConfigSettings copyWith({
+    Duration? fetchTimeout,
+    Duration? minimumFetchInterval,
+  }) {
+    return RemoteConfigSettings(
+      fetchTimeout: fetchTimeout ?? this.fetchTimeout,
+      minimumFetchInterval: minimumFetchInterval ?? this.minimumFetchInterval,
+    );
+  }
+
+  @override
+  List<Object> get props => [fetchTimeout, minimumFetchInterval];
+}

--- a/lib/shared/config/remote_config/domain/entities/remote_config_value.dart
+++ b/lib/shared/config/remote_config/domain/entities/remote_config_value.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+enum RemoteConfigValueSource { remote, defaultValue, staticValue }
+
+class RemoteConfigValue<T> extends Equatable {
+  const RemoteConfigValue({
+    required this.key,
+    required this.value,
+    required this.source,
+    this.lastFetchTime,
+    this.usedFallback = false,
+  });
+
+  final String key;
+  final T value;
+  final RemoteConfigValueSource source;
+  final DateTime? lastFetchTime;
+  final bool usedFallback;
+
+  bool get isRemote => source == RemoteConfigValueSource.remote;
+  bool get isDefault => source == RemoteConfigValueSource.defaultValue;
+  bool get isStatic => source == RemoteConfigValueSource.staticValue;
+
+  @override
+  List<Object?> get props => [key, value, source, lastFetchTime, usedFallback];
+
+  RemoteConfigValue<R> mapValue<R>(R newValue, {bool? usedFallbackOverride}) {
+    return RemoteConfigValue<R>(
+      key: key,
+      value: newValue,
+      source: source,
+      lastFetchTime: lastFetchTime,
+      usedFallback: usedFallbackOverride ?? usedFallback,
+    );
+  }
+}

--- a/lib/shared/config/remote_config/domain/repositories/remote_config_repository.dart
+++ b/lib/shared/config/remote_config/domain/repositories/remote_config_repository.dart
@@ -1,0 +1,46 @@
+import 'package:dartz/dartz.dart';
+import 'package:devhub_gpt/core/errors/failures.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+
+abstract class RemoteConfigRepository {
+  bool get isInitialized;
+  RemoteConfigMetadata? get lastMetadata;
+
+  Future<Either<Failure, RemoteConfigMetadata>> initialize({
+    RemoteConfigSettings? settings,
+    Map<String, Object> defaults = const <String, Object>{},
+    bool forceRefresh = false,
+  });
+
+  Future<Either<Failure, RemoteConfigMetadata>> refresh({
+    bool force = false,
+  });
+
+  RemoteConfigValue<bool> getBool(
+    String key, {
+    bool fallback = false,
+  });
+
+  RemoteConfigValue<int> getInt(
+    String key, {
+    int fallback = 0,
+  });
+
+  RemoteConfigValue<double> getDouble(
+    String key, {
+    double fallback = 0.0,
+  });
+
+  RemoteConfigValue<String> getString(
+    String key, {
+    String fallback = '',
+  });
+
+  RemoteConfigValue<List<String>> getStringList(
+    String key, {
+    List<String> fallback = const <String>[],
+    String separator = ',',
+  });
+}

--- a/lib/shared/config/remote_config/presentation/widgets/remote_config_welcome_banner.dart
+++ b/lib/shared/config/remote_config/presentation/widgets/remote_config_welcome_banner.dart
@@ -1,0 +1,76 @@
+import 'package:devhub_gpt/shared/config/remote_config/application/remote_config_controller.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class RemoteConfigWelcomeBanner extends ConsumerWidget {
+  const RemoteConfigWelcomeBanner({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final RemoteConfigFeatureFlags? flags =
+        ref.watch(remoteConfigFeatureFlagsProvider);
+    if (flags == null ||
+        !flags.welcomeBannerEnabled ||
+        flags.welcomeMessage.trim().isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+
+    final int maxLines = flags.markdownMaxLines <= 0
+        ? 1
+        : flags.markdownMaxLines > 8
+            ? 8
+            : flags.markdownMaxLines;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.surfaceVariant,
+          borderRadius: const BorderRadius.all(Radius.circular(12)),
+          border: Border.all(color: colors.outlineVariant),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Icon(
+                Icons.campaign_outlined,
+                color: colors.primary,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    Text(
+                      'Remote config update',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: colors.onSurface,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      flags.welcomeMessage,
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: colors.onSurfaceVariant,
+                      ),
+                      maxLines: maxLines,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/config/remote_config/remote_config_defaults.dart
+++ b/lib/shared/config/remote_config/remote_config_defaults.dart
@@ -1,0 +1,18 @@
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_keys.dart';
+
+class RemoteConfigDefaults {
+  static const bool welcomeBannerEnabled = true;
+  static const int markdownMaxLines = 6;
+  static const String supportedLocalesCsv = 'en,uk';
+  static const List<String> supportedLocalesList = <String>['en', 'uk'];
+  static const String appThemeMode = 'system';
+  static const String welcomeMessage = 'Welcome to DevHub!';
+
+  static Map<String, Object> asMap() => <String, Object>{
+        RemoteConfigKeys.welcomeBannerEnabled: welcomeBannerEnabled,
+        RemoteConfigKeys.markdownMaxLines: markdownMaxLines,
+        RemoteConfigKeys.supportedLocales: supportedLocalesCsv,
+        RemoteConfigKeys.appThemeMode: appThemeMode,
+        RemoteConfigKeys.welcomeMessage: welcomeMessage,
+      };
+}

--- a/lib/shared/config/remote_config/remote_config_keys.dart
+++ b/lib/shared/config/remote_config/remote_config_keys.dart
@@ -1,0 +1,7 @@
+class RemoteConfigKeys {
+  static const String welcomeBannerEnabled = 'welcome_banner_enabled';
+  static const String markdownMaxLines = 'markdown_max_lines';
+  static const String supportedLocales = 'supported_locales';
+  static const String appThemeMode = 'app_theme_mode';
+  static const String welcomeMessage = 'welcome_message';
+}

--- a/lib/shared/config/remote_config/remote_config_providers.dart
+++ b/lib/shared/config/remote_config/remote_config_providers.dart
@@ -1,0 +1,37 @@
+import 'dart:developer';
+
+import 'package:devhub_gpt/core/constants/firebase_flags.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/firebase_remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/in_memory_remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/repositories/remote_config_repository_impl.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/repositories/remote_config_repository.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_defaults.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_remote_config/firebase_remote_config.dart'
+    as firebase_remote_config;
+
+final remoteConfigDefaultsProvider = Provider<Map<String, Object>>((ref) {
+  return RemoteConfigDefaults.asMap();
+});
+
+final remoteConfigDataSourceProvider = Provider<RemoteConfigDataSource>((ref) {
+  if (!kUseFirebaseRemoteConfig || !isFirebaseInitialized) {
+    return InMemoryRemoteConfigDataSource();
+  }
+  try {
+    final firebase_remote_config.FirebaseRemoteConfig instance =
+        firebase_remote_config.FirebaseRemoteConfig.instance;
+    return FirebaseRemoteConfigDataSource(instance);
+  } catch (error, stackTrace) {
+    log('Falling back to in-memory Remote Config data source: $error');
+    log(stackTrace.toString());
+    return InMemoryRemoteConfigDataSource();
+  }
+});
+
+final remoteConfigRepositoryProvider = Provider<RemoteConfigRepository>((ref) {
+  final RemoteConfigDataSource dataSource =
+      ref.watch(remoteConfigDataSourceProvider);
+  return RemoteConfigRepositoryImpl(dataSource);
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,6 +401,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  firebase_remote_config:
+    dependency: "direct main"
+    description:
+      name: firebase_remote_config
+      sha256: "6406d65d88d41891d201095d1a6bff8ecabe91f3097090db00900d53826f2f9f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.2"
+  firebase_remote_config_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_platform_interface
+      sha256: "60ec31cc11bcf2f416e86dd77521784b7dc4be1b82118ca10a1ce9a29fa85e09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
+  firebase_remote_config_web:
+    dependency: transitive
+    description:
+      name: firebase_remote_config_web
+      sha256: "864791054997d63987e0fbb2d7b175ab04e41060a9315b7eeddba2974603247c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.12"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   firebase_core: ^4.1.1
   firebase_auth: ^6.1.0
   firebase_messaging: ^16.0.2
+  firebase_remote_config: ^6.0.2
 
 dev_dependencies:
   drift_dev: ^2.28.3

--- a/test/shared/config/remote_config/remote_config_controller_test.dart
+++ b/test/shared/config/remote_config/remote_config_controller_test.dart
@@ -1,0 +1,194 @@
+import 'package:dartz/dartz.dart';
+import 'package:devhub_gpt/core/errors/failures.dart';
+import 'package:devhub_gpt/shared/config/remote_config/application/remote_config_controller.dart';
+import 'package:devhub_gpt/shared/config/remote_config/application/remote_config_state.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/repositories/remote_config_repository.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_defaults.dart';
+import 'package:devhub_gpt/shared/config/remote_config/remote_config_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockRemoteConfigRepository extends Mock
+    implements RemoteConfigRepository {}
+
+void main() {
+  late ProviderContainer container;
+  late RemoteConfigRepository repository;
+
+  setUpAll(() {
+    registerFallbackValue(const RemoteConfigSettings());
+    registerFallbackValue(const <String, Object>{});
+  });
+
+  setUp(() {
+    repository = _MockRemoteConfigRepository();
+    container = ProviderContainer(
+      overrides: [
+        remoteConfigRepositoryProvider.overrideWithValue(repository),
+        remoteConfigDefaultsProvider.overrideWithValue(
+          RemoteConfigDefaults.asMap(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  RemoteConfigValue<T> _remoteValue<T>(T value) {
+    return RemoteConfigValue<T>(
+      key: 'key',
+      value: value,
+      source: RemoteConfigValueSource.remote,
+      lastFetchTime: DateTime(2024, 1, 1),
+    );
+  }
+
+  Future<void> _pumpController() async {
+    await container.read(remoteConfigControllerProvider.future);
+  }
+
+  group('initialize', () {
+    test('emits data state when initialization succeeds', () async {
+      final metadata = RemoteConfigMetadata(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() => repository.initialize(
+            settings: any(named: 'settings'),
+            defaults: any(named: 'defaults'),
+            forceRefresh: any(named: 'forceRefresh'),
+          )).thenAnswer((_) async => Right(metadata));
+      when(() => repository.getBool(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<bool>(true));
+      when(() => repository.getInt(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<int>(10));
+      when(() => repository.getStringList(
+            any(),
+            fallback: any(named: 'fallback'),
+            separator: any(named: 'separator'),
+          )).thenReturn(
+        RemoteConfigValue<List<String>>(
+          key: 'supported_locales',
+          value: const <String>['en', 'uk'],
+          source: RemoteConfigValueSource.remote,
+          lastFetchTime: DateTime(2024, 1, 1),
+        ),
+      );
+      when(() => repository.getString(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<String>('dark'));
+
+      await _pumpController();
+
+      final state = container.read(remoteConfigControllerProvider).requireValue;
+      expect(state.metadata, equals(metadata));
+      expect(state.flags.welcomeBannerEnabled, isTrue);
+      expect(state.flags.markdownMaxLines, equals(10));
+      expect(state.flags.forcedThemeMode, equals(ThemeMode.dark));
+    });
+
+    test('emits error state when initialization fails', () async {
+      final failure = ServerFailure('init failed');
+      when(() => repository.initialize(
+            settings: any(named: 'settings'),
+            defaults: any(named: 'defaults'),
+            forceRefresh: any(named: 'forceRefresh'),
+          )).thenAnswer((_) async => Left(failure));
+
+      container.read(remoteConfigControllerProvider);
+      await pumpEventQueue(times: 5);
+
+      final state = container.read(remoteConfigControllerProvider);
+      expect(state.hasError, isTrue);
+      expect(state.error, equals(failure));
+    });
+  });
+
+  group('refresh', () {
+    Future<void> _prepareInitializedState() async {
+      final metadata = RemoteConfigMetadata(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() => repository.initialize(
+            settings: any(named: 'settings'),
+            defaults: any(named: 'defaults'),
+            forceRefresh: any(named: 'forceRefresh'),
+          )).thenAnswer((_) async => Right(metadata));
+      when(() => repository.getBool(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<bool>(true));
+      when(() => repository.getInt(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<int>(6));
+      when(() => repository.getStringList(
+            any(),
+            fallback: any(named: 'fallback'),
+            separator: any(named: 'separator'),
+          )).thenReturn(
+        RemoteConfigValue<List<String>>(
+          key: 'supported_locales',
+          value: const <String>['en', 'uk'],
+          source: RemoteConfigValueSource.remote,
+          lastFetchTime: DateTime(2024, 1, 1),
+        ),
+      );
+      when(() => repository.getString(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<String>('system'));
+      await _pumpController();
+    }
+
+    test('refresh updates state with latest metadata', () async {
+      await _prepareInitializedState();
+      final refreshedMetadata = RemoteConfigMetadata(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 2, 2),
+      );
+      when(() => repository.refresh(force: any(named: 'force')))
+          .thenAnswer((_) async => Right(refreshedMetadata));
+      when(() => repository.getBool(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<bool>(false));
+      when(() => repository.getInt(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<int>(4));
+      when(() => repository.getStringList(
+            any(),
+            fallback: any(named: 'fallback'),
+            separator: any(named: 'separator'),
+          )).thenReturn(
+        RemoteConfigValue<List<String>>(
+          key: 'supported_locales',
+          value: const <String>['en'],
+          source: RemoteConfigValueSource.remote,
+          lastFetchTime: DateTime(2024, 2, 2),
+        ),
+      );
+      when(() => repository.getString(any(), fallback: any(named: 'fallback')))
+          .thenReturn(_remoteValue<String>('light'));
+
+      await container
+          .read(remoteConfigControllerProvider.notifier)
+          .refresh(force: true);
+
+      final state = container.read(remoteConfigControllerProvider).requireValue;
+      expect(state.metadata, equals(refreshedMetadata));
+      expect(state.flags.welcomeBannerEnabled, isFalse);
+      expect(state.flags.markdownMaxLines, equals(4));
+      expect(state.flags.supportedLocales, equals(const <String>['en']));
+      expect(state.flags.forcedThemeMode, equals(ThemeMode.light));
+    });
+
+    test('refresh emits error when repository returns failure', () async {
+      await _prepareInitializedState();
+      final failure = ServerFailure('refresh failed');
+      when(() => repository.refresh(force: any(named: 'force')))
+          .thenAnswer((_) async => Left(failure));
+
+      await container.read(remoteConfigControllerProvider.notifier).refresh();
+
+      final state = container.read(remoteConfigControllerProvider);
+      expect(state.hasError, isTrue);
+      expect(state.error, equals(failure));
+    });
+  });
+}

--- a/test/shared/config/remote_config/remote_config_repository_impl_test.dart
+++ b/test/shared/config/remote_config/remote_config_repository_impl_test.dart
@@ -1,0 +1,195 @@
+import 'package:dartz/dartz.dart';
+import 'package:devhub_gpt/core/errors/failures.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/datasources/remote_config_data_source.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_metadata_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/models/remote_config_value_model.dart';
+import 'package:devhub_gpt/shared/config/remote_config/data/repositories/remote_config_repository_impl.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_metadata.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_settings.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_value.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockRemoteConfigDataSource extends Mock
+    implements RemoteConfigDataSource {}
+
+void main() {
+  late RemoteConfigRepositoryImpl repository;
+  late RemoteConfigDataSource remoteDataSource;
+
+  setUpAll(() {
+    registerFallbackValue(const RemoteConfigSettings());
+    registerFallbackValue(const <String, Object>{});
+  });
+
+  setUp(() {
+    remoteDataSource = _MockRemoteConfigDataSource();
+    repository = RemoteConfigRepositoryImpl(remoteDataSource);
+  });
+
+  group('initialize', () {
+    test('returns metadata and marks repository as initialized on success',
+        () async {
+      final metadata = RemoteConfigMetadataModel(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() => remoteDataSource.ensureInitialized(
+            settings: any(named: 'settings'),
+            defaultValues: any(named: 'defaultValues'),
+          )).thenAnswer((_) async {});
+      when(() => remoteDataSource.fetchAndActivate(force: any(named: 'force')))
+          .thenAnswer((_) async => true);
+      when(() => remoteDataSource.getMetadata()).thenReturn(metadata);
+
+      final result = await repository.initialize(
+        defaults: <String, Object>{'welcome_banner_enabled': true},
+      );
+
+      expect(result.isRight(), isTrue);
+      expect(repository.isInitialized, isTrue);
+      expect(repository.lastMetadata, equals(metadata));
+      verify(() => remoteDataSource.ensureInitialized(
+            settings: any(named: 'settings'),
+            defaultValues: any(named: 'defaultValues'),
+          )).called(1);
+      verify(() =>
+              remoteDataSource.fetchAndActivate(force: any(named: 'force')))
+          .called(1);
+    });
+
+    test('returns failure when data source throws FirebaseException', () async {
+      when(() => remoteDataSource.ensureInitialized(
+            settings: any(named: 'settings'),
+            defaultValues: any(named: 'defaultValues'),
+          )).thenThrow(
+        FirebaseException(plugin: 'firebase_remote_config', message: 'boom'),
+      );
+
+      final result = await repository.initialize();
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<ServerFailure>()),
+        (_) => fail('Expected failure'),
+      );
+      expect(repository.isInitialized, isFalse);
+    });
+  });
+
+  group('refresh', () {
+    test('returns failure when repository was not initialized', () async {
+      final result = await repository.refresh();
+
+      expect(result.isLeft(), isTrue);
+      result.fold(
+        (failure) => expect(failure, isA<CacheFailure>()),
+        (_) => fail('Expected failure'),
+      );
+    });
+
+    test('refreshes metadata when initialized', () async {
+      final initialMetadata = RemoteConfigMetadataModel(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() => remoteDataSource.ensureInitialized(
+            settings: any(named: 'settings'),
+            defaultValues: any(named: 'defaultValues'),
+          )).thenAnswer((_) async {});
+      when(() => remoteDataSource.fetchAndActivate(force: any(named: 'force')))
+          .thenAnswer((_) async => true);
+      when(() => remoteDataSource.getMetadata()).thenReturn(initialMetadata);
+
+      await repository.initialize();
+
+      final refreshedMetadata = RemoteConfigMetadataModel(
+        lastFetchStatus: RemoteConfigLastFetchStatus.success,
+        lastFetchTime: DateTime(2024, 2, 2),
+      );
+      when(() => remoteDataSource.getMetadata()).thenReturn(refreshedMetadata);
+
+      final result = await repository.refresh(force: true);
+
+      expect(result.isRight(), isTrue);
+      expect(repository.lastMetadata, equals(refreshedMetadata));
+      verify(() => remoteDataSource.fetchAndActivate(force: true)).called(1);
+    });
+  });
+
+  group('value getters', () {
+    test('getBool forwards to data source', () {
+      const key = 'welcome_banner_enabled';
+      final model = RemoteConfigValueModel<bool>(
+        key: key,
+        value: true,
+        source: RemoteConfigValueSource.remote,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() =>
+              remoteDataSource.getBool(key, fallback: any(named: 'fallback')))
+          .thenReturn(model);
+
+      final value = repository.getBool(key, fallback: false);
+
+      expect(value.value, isTrue);
+      expect(value.isRemote, isTrue);
+    });
+
+    test('getStringList parses comma separated values', () {
+      const key = 'supported_locales';
+      final model = RemoteConfigValueModel<String>(
+        key: key,
+        value: 'en,uk,pl',
+        source: RemoteConfigValueSource.remote,
+        lastFetchTime: DateTime(2024, 1, 1),
+      );
+      when(() =>
+              remoteDataSource.getString(key, fallback: any(named: 'fallback')))
+          .thenReturn(model);
+
+      final value = repository.getStringList(key, fallback: const ['en', 'uk']);
+
+      expect(value.value, equals(<String>['en', 'uk', 'pl']));
+      expect(value.isRemote, isTrue);
+    });
+
+    test('getStringList falls back when static value', () {
+      const key = 'supported_locales';
+      final model = RemoteConfigValueModel<String>(
+        key: key,
+        value: '',
+        source: RemoteConfigValueSource.staticValue,
+        lastFetchTime: null,
+        usedFallback: true,
+      );
+      when(() =>
+              remoteDataSource.getString(key, fallback: any(named: 'fallback')))
+          .thenReturn(model);
+
+      final value = repository.getStringList(key, fallback: const ['en']);
+
+      expect(value.value, equals(<String>['en']));
+      expect(value.usedFallback, isTrue);
+    });
+
+    test('getStringList parses JSON array strings', () {
+      const key = 'supported_locales';
+      final model = RemoteConfigValueModel<String>(
+        key: key,
+        value: '["en","uk"]',
+        source: RemoteConfigValueSource.remote,
+        lastFetchTime: null,
+      );
+      when(() =>
+              remoteDataSource.getString(key, fallback: any(named: 'fallback')))
+          .thenReturn(model);
+
+      final value = repository.getStringList(key, fallback: const ['en']);
+
+      expect(value.value, equals(<String>['en', 'uk']));
+    });
+  });
+}

--- a/test/shared/config/remote_config/remote_config_welcome_banner_test.dart
+++ b/test/shared/config/remote_config/remote_config_welcome_banner_test.dart
@@ -1,0 +1,74 @@
+import 'package:devhub_gpt/shared/config/remote_config/application/remote_config_controller.dart';
+import 'package:devhub_gpt/shared/config/remote_config/domain/entities/remote_config_feature_flags.dart';
+import 'package:devhub_gpt/shared/config/remote_config/presentation/widgets/remote_config_welcome_banner.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  RemoteConfigFeatureFlags _flags({
+    bool enabled = true,
+    String message = 'Remote updates are live! 🎉',
+    int maxLines = 4,
+    List<String> locales = const <String>['en'],
+  }) {
+    return RemoteConfigFeatureFlags(
+      welcomeBannerEnabled: enabled,
+      markdownMaxLines: maxLines,
+      supportedLocales: locales,
+      forcedThemeMode: null,
+      welcomeMessage: message,
+    );
+  }
+
+  Future<void> _pumpBanner(
+    WidgetTester tester, {
+    RemoteConfigFeatureFlags? flags,
+  }) {
+    return tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          remoteConfigFeatureFlagsProvider.overrideWithValue(flags),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: RemoteConfigWelcomeBanner(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('does not render when flags are null', (tester) async {
+    await _pumpBanner(tester, flags: null);
+
+    expect(find.byType(RemoteConfigWelcomeBanner), findsOneWidget);
+    expect(find.byIcon(Icons.campaign_outlined), findsNothing);
+  });
+
+  testWidgets('does not render when banner is disabled', (tester) async {
+    await _pumpBanner(tester, flags: _flags(enabled: false));
+
+    expect(find.byIcon(Icons.campaign_outlined), findsNothing);
+  });
+
+  testWidgets('renders message when enabled', (tester) async {
+    const String message = 'Welcome to DevHub!';
+    await _pumpBanner(tester, flags: _flags(message: message));
+
+    expect(find.byIcon(Icons.campaign_outlined), findsOneWidget);
+    expect(find.text('Remote config update'), findsOneWidget);
+    expect(find.text(message), findsOneWidget);
+  });
+
+  testWidgets('respects max lines from remote config', (tester) async {
+    await _pumpBanner(
+      tester,
+      flags: _flags(message: 'line1\nline2\nline3', maxLines: 2),
+    );
+
+    final Text messageText =
+        tester.widget<Text>(find.text('line1\nline2\nline3'));
+    expect(messageText.maxLines, equals(2));
+  });
+}


### PR DESCRIPTION
## Summary
- add a RemoteConfigWelcomeBanner widget that renders remote-config driven announcements when enabled
- surface the banner in the main shell so users see the latest remote message above the app content
- add widget tests that verify banner visibility, messaging, and max-line handling

## Testing
- flutter test test/shared/config/remote_config/remote_config_welcome_banner_test.dart
- flutter test test/shared/config/remote_config/remote_config_repository_impl_test.dart
- flutter test test/shared/config/remote_config/remote_config_controller_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68d64ea65dd08333966c990f422479c3