### PR TITLE
feat: add compression workflow controls and downloads

### DIFF
--- a/lib/features/files/application/file_saver.dart
+++ b/lib/features/files/application/file_saver.dart
@@ -1,0 +1,8 @@
+import 'file_saver_interface.dart';
+import 'file_saver_stub.dart'
+    if (dart.library.html) 'file_saver_web.dart'
+    if (dart.library.io) 'file_saver_io.dart';
+
+export 'file_saver_interface.dart';
+
+FileSaver createFileSaver() => createPlatformFileSaver();

--- a/lib/features/files/application/file_saver_interface.dart
+++ b/lib/features/files/application/file_saver_interface.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+abstract class FileSaver {
+  Future<String?> save({required String filename, required Uint8List bytes});
+}

--- a/lib/features/files/application/file_saver_io.dart
+++ b/lib/features/files/application/file_saver_io.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+
+import 'file_saver_interface.dart';
+
+class IoFileSaver implements FileSaver {
+  IoFileSaver({Directory? targetDirectory})
+    : _targetDirectory = targetDirectory;
+
+  final Directory? _targetDirectory;
+
+  @override
+  Future<String?> save({
+    required String filename,
+    required Uint8List bytes,
+  }) async {
+    final directory = await _resolveDirectory();
+    await directory.create(recursive: true);
+    final sanitizedName = filename.replaceAll(RegExp(r'[\\/:*?"<>|]'), '_');
+    final file = File(p.join(directory.path, sanitizedName));
+    await file.writeAsBytes(bytes, flush: true);
+    return file.path;
+  }
+
+  Future<Directory> _resolveDirectory() async {
+    final override = _targetDirectory;
+    if (override != null) {
+      return override;
+    }
+    final downloads = await _findDownloadsDirectory();
+    if (downloads != null) {
+      return downloads;
+    }
+    return Directory.systemTemp;
+  }
+
+  Future<Directory?> _findDownloadsDirectory() async {
+    final env = Platform.environment;
+    if (Platform.isMacOS || Platform.isLinux) {
+      final home = env['HOME'];
+      if (home != null) {
+        final directory = Directory(p.join(home, 'Downloads'));
+        if (await directory.exists()) {
+          return directory;
+        }
+      }
+    } else if (Platform.isWindows) {
+      final userProfile = env['USERPROFILE'];
+      if (userProfile != null) {
+        final directory = Directory(p.join(userProfile, 'Downloads'));
+        if (await directory.exists()) {
+          return directory;
+        }
+      }
+    }
+    return null;
+  }
+}
+
+FileSaver createPlatformFileSaver() => IoFileSaver();

--- a/lib/features/files/application/file_saver_stub.dart
+++ b/lib/features/files/application/file_saver_stub.dart
@@ -1,0 +1,4 @@
+import 'file_saver_interface.dart';
+
+FileSaver createPlatformFileSaver() =>
+    throw UnsupportedError('File saving is not supported on this platform');

--- a/lib/features/files/application/file_saver_web.dart
+++ b/lib/features/files/application/file_saver_web.dart
@@ -1,0 +1,26 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'file_saver_interface.dart';
+
+class WebFileSaver implements FileSaver {
+  @override
+  Future<String?> save({
+    required String filename,
+    required Uint8List bytes,
+  }) async {
+    final blob = html.Blob([bytes]);
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor = html.AnchorElement(href: url)
+      ..download = filename
+      ..style.display = 'none';
+    html.document.body?.append(anchor);
+    anchor.click();
+    anchor.remove();
+    html.Url.revokeObjectUrl(url);
+    return null;
+  }
+}
+
+FileSaver createPlatformFileSaver() => WebFileSaver();

--- a/lib/features/files/domain/entities/uploaded_file.dart
+++ b/lib/features/files/domain/entities/uploaded_file.dart
@@ -1,15 +1,22 @@
 import 'dart:typed_data';
 
-enum UploadStatus { preparing, uploading, completed, failed }
+enum UploadStatus {
+  preparing,
+  uploading,
+  waitingForCompression,
+  compressing,
+  completed,
+  failed,
+}
 
 enum UploadMode { standard, photo, video }
 
 extension UploadModeX on UploadMode {
   String get label => switch (this) {
-        UploadMode.standard => 'Звичайний файл',
-        UploadMode.photo => 'Фото',
-        UploadMode.video => 'Відео',
-      };
+    UploadMode.standard => 'Звичайний файл',
+    UploadMode.photo => 'Фото',
+    UploadMode.video => 'Відео',
+  };
 }
 
 class UploadedFile {

--- a/test/unit/files/file_upload_notifier_test.dart
+++ b/test/unit/files/file_upload_notifier_test.dart
@@ -1,0 +1,126 @@
+import 'dart:typed_data';
+
+import 'package:devhub_gpt/features/files/domain/entities/uploaded_file.dart';
+import 'package:devhub_gpt/features/files/presentation/providers/file_upload_providers.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FileUploadNotifier', () {
+    late ProviderContainer container;
+    late FileUploadNotifier notifier;
+
+    setUp(() {
+      container = ProviderContainer();
+      notifier = container.read(fileUploadControllerProvider.notifier);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test(
+      'processPickedFiles transitions photo uploads to waiting state',
+      () async {
+        final image = img.Image(width: 64, height: 64);
+        final bytes = Uint8List.fromList(img.encodeJpg(image, quality: 90));
+        final file = PlatformFile(
+          name: 'sample.jpg',
+          size: bytes.length,
+          bytes: bytes,
+        );
+
+        await notifier.processPickedFiles([file], UploadMode.photo);
+
+        final uploads = container.read(fileUploadControllerProvider);
+        expect(uploads, hasLength(1));
+        final uploaded = uploads.first;
+        expect(uploaded.status, UploadStatus.waitingForCompression);
+        expect(uploaded.progress, greaterThan(0));
+        expect(container.read(fileUploadModeLockedProvider), isTrue);
+      },
+    );
+
+    test('compressPending compresses photo uploads', () async {
+      final image = img.Image(width: 128, height: 128);
+      final originalBytes = Uint8List.fromList(img.encodePng(image));
+      final file = PlatformFile(
+        name: 'large.png',
+        size: originalBytes.length,
+        bytes: originalBytes,
+      );
+
+      await notifier.processPickedFiles([file], UploadMode.photo);
+      await notifier.compressPending();
+
+      final uploads = container.read(fileUploadControllerProvider);
+      final uploaded = uploads.single;
+      expect(uploaded.status, UploadStatus.completed);
+      expect(uploaded.bytes, isNotNull);
+      expect(uploaded.processedSize, equals(uploaded.bytes!.length));
+      expect(uploaded.bytes, isNotEmpty);
+      expect(uploaded.progress, 1);
+    });
+
+    test('compressPending compresses video uploads', () async {
+      final data = Uint8List.fromList(List<int>.filled(4096, 7));
+      final file = PlatformFile(
+        name: 'clip.mp4',
+        size: data.length,
+        bytes: data,
+      );
+
+      await notifier.processPickedFiles([file], UploadMode.video);
+      await notifier.compressPending();
+
+      final uploads = container.read(fileUploadControllerProvider);
+      final uploaded = uploads.single;
+      expect(uploaded.status, UploadStatus.completed);
+      expect(uploaded.bytes, isNotNull);
+      expect(uploaded.processedSize, isNotNull);
+      expect(uploaded.processedSize, lessThan(uploaded.size));
+    });
+
+    test(
+      'processPickedFiles fails for unsupported extension in compression mode',
+      () async {
+        final data = Uint8List.fromList(
+          List<int>.generate(128, (index) => index),
+        );
+        final file = PlatformFile(
+          name: 'notes.txt',
+          size: data.length,
+          bytes: data,
+        );
+
+        await notifier.processPickedFiles([file], UploadMode.photo);
+
+        final uploads = container.read(fileUploadControllerProvider);
+        final uploaded = uploads.single;
+        expect(uploaded.status, UploadStatus.failed);
+        expect(uploaded.errorMessage, contains('Формат файлу'));
+      },
+    );
+
+    test('standard uploads complete immediately', () async {
+      final data = Uint8List.fromList(List<int>.filled(256, 42));
+      final file = PlatformFile(
+        name: 'document.bin',
+        size: data.length,
+        bytes: data,
+      );
+
+      await notifier.processPickedFiles([file], UploadMode.standard);
+
+      final uploads = container.read(fileUploadControllerProvider);
+      final uploaded = uploads.single;
+      expect(uploaded.status, UploadStatus.completed);
+      expect(uploaded.bytes, isNotNull);
+      expect(uploaded.processedSize, equals(uploaded.bytes!.length));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add platform-aware file saver helpers for downloading compression results
- restructure the file upload notifier to gate compression, lock modes, and track pending bytes
- refresh the upload card UI with workflow controls, manual compression, and per-file download actions
- cover the new compression flow with focused notifier unit tests

## Testing
- flutter test test/unit/files/file_upload_notifier_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68d733bd50808333a1da64d2fc580ead