### PR TITLE
Add caching and retry support to Dio HTTP client

### DIFF
--- a/lib/shared/providers/dio_provider.dart
+++ b/lib/shared/providers/dio_provider.dart
@@ -1,8 +1,23 @@
+import 'package:devhub_gpt/core/utils/app_logger.dart';
 import 'package:devhub_gpt/shared/config/env.dart';
 import 'package:devhub_gpt/shared/network/logging_interceptor.dart';
 import 'package:devhub_gpt/shared/network/tls_pinning.dart';
 import 'package:dio/dio.dart';
+import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final dioCacheOptionsProvider = Provider<CacheOptions>((ref) {
+  return CacheOptions(
+    store: MemCacheStore(),
+    policy: CachePolicy.refreshForceCache,
+    // Allow using cached data when the backend is temporarily failing.
+    hitCacheOnErrorExcept: [401, 403],
+    maxStale: const Duration(hours: 12),
+    priority: CachePriority.normal,
+    allowPostMethod: false,
+  );
+});
 
 final dioProvider = Provider<Dio>((ref) {
   final dio = Dio(
@@ -14,9 +29,37 @@ final dioProvider = Provider<Dio>((ref) {
       headers: {'Accept': 'application/json'},
     ),
   );
-  dio.interceptors.addAll([LoggingInterceptor()]);
+  final cacheOptions = ref.read(dioCacheOptionsProvider);
+  dio.interceptors.addAll([
+    DioCacheInterceptor(options: cacheOptions),
+    RetryInterceptor(
+      dio: dio,
+      retries: 3,
+      retryDelays: const [
+        Duration(milliseconds: 120),
+        Duration(milliseconds: 300),
+        Duration(milliseconds: 600),
+      ],
+      retryEvaluator: _shouldRetry,
+      logPrint: (obj) => AppLogger.info('[HTTP][retry] $obj', area: 'http'),
+    ),
+    LoggingInterceptor(),
+  ]);
   // Apply TLS pinning for primary backend only (not for GitHub).
   final baseUri = Uri.parse(Env.apiBaseUrl);
   applyTlsPinningIfEnabled(dio, baseUri);
   return dio;
 });
+
+bool _shouldRetry(DioException error, int attempt) {
+  if (error.type == DioExceptionType.cancel) {
+    return false;
+  }
+  if (error.type == DioExceptionType.badResponse) {
+    final status = error.response?.statusCode ?? 0;
+    // Retry only on server errors.
+    return status >= 500 && status < 600;
+  }
+  // Retry for network/timeout errors.
+  return error.type != DioExceptionType.badCertificate;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -273,6 +273,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.9.0"
+  dio_cache_interceptor:
+    dependency: "direct main"
+    description:
+      name: dio_cache_interceptor
+      sha256: "1346705a2057c265014d7696e3e2318b560bfb00b484dac7f9b01e2ceaebb07d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.1"
+  dio_smart_retry:
+    dependency: "direct main"
+    description:
+      name: dio_smart_retry
+      sha256: c8e20da5f49289fa7dce5c9c6b5b120928e3661aefa0fa2d206ea6d93f580928
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   dio_web_adapter:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
 
   # Networking
   dio: ^5.9.0
+  dio_cache_interceptor: ^3.5.0
+  dio_smart_retry: ^7.0.1
   retrofit: ^4.7.2
   pretty_dio_logger: ^1.4.0
   markdown_widget: ^2.3.2+8

--- a/test/shared/providers/dio_provider_test.dart
+++ b/test/shared/providers/dio_provider_test.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+
+import 'package:devhub_gpt/shared/config/env.dart';
+import 'package:devhub_gpt/shared/network/logging_interceptor.dart';
+import 'package:devhub_gpt/shared/providers/dio_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('dioProvider', () {
+    test('configures dio base options and core interceptors', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final dio = container.read(dioProvider);
+
+      expect(dio.options.baseUrl, Env.apiBaseUrl);
+      expect(
+        dio.interceptors.whereType<DioCacheInterceptor>().length,
+        1,
+      );
+      expect(
+        dio.interceptors.whereType<RetryInterceptor>().length,
+        1,
+      );
+      expect(
+        dio.interceptors
+            .any((interceptor) => interceptor is LoggingInterceptor),
+        isTrue,
+      );
+    });
+
+    test('serves cached responses when forceCache policy is used', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final dio = container.read(dioProvider);
+      final cacheOptions = container.read(dioCacheOptionsProvider);
+      final adapter = _RecordingAdapter();
+      dio.httpClientAdapter = adapter;
+
+      final response1 = await dio.get(
+        '/cache-test',
+        options: cacheOptions.toOptions(),
+      );
+      expect(response1.data, {'hit': 1});
+      expect(adapter.requestCount, 1);
+
+      final cacheKey = cacheOptions.keyBuilder(response1.requestOptions);
+      final cachedEntry = await cacheOptions.store!.get(cacheKey);
+      expect(cachedEntry, isNotNull);
+
+      adapter.shouldFail = true;
+      final cachedOptions =
+          cacheOptions.copyWith(policy: CachePolicy.forceCache);
+      final response2 = await dio.get(
+        '/cache-test',
+        options: cachedOptions.toOptions(),
+      );
+      expect(response2.data, {'hit': 1});
+      expect(adapter.requestCount, 1,
+          reason: 'No extra network calls expected');
+    });
+
+    test('retries transient failures once and then succeeds', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final dio = container.read(dioProvider);
+      final adapter = _RetryingAdapter();
+      dio.httpClientAdapter = adapter;
+
+      final response = await dio.get('/retry-test');
+
+      expect(response.data, 'ok');
+      expect(adapter.attempts, 2);
+    });
+  });
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  int requestCount = 0;
+  bool shouldFail = false;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requestCount += 1;
+    if (shouldFail) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionError,
+        error: 'offline',
+      );
+    }
+    return ResponseBody.fromString(
+      jsonEncode({'hit': requestCount}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}
+
+class _RetryingAdapter implements HttpClientAdapter {
+  int attempts = 0;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    attempts += 1;
+    if (attempts == 1) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionError,
+        error: 'temporary network issue',
+      );
+    }
+    return ResponseBody.fromString(
+      jsonEncode('ok'),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add cache and retry interceptors to the shared Dio client and expose cache options via Riverpod
- wire up dio_cache_interceptor and dio_smart_retry dependencies for the HTTP stack
- cover the new HTTP behaviour with dedicated provider tests for caching and retry logic

## Testing
- flutter test test/shared/providers/dio_provider_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68dbe8bce9b4833386dc6ea92386be15