### PR TITLE
Implement GitHub REST Retrofit client and GraphQL integration

### DIFF
--- a/lib/features/github/data/datasources/github_graphql_data_source.dart
+++ b/lib/features/github/data/datasources/github_graphql_data_source.dart
@@ -1,0 +1,130 @@
+import 'package:devhub_gpt/core/utils/app_logger.dart';
+import 'package:devhub_gpt/features/github/domain/entities/repo_language_stat.dart';
+import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
+import 'package:devhub_gpt/shared/providers/github_graphql_client_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphql/client.dart';
+
+class GithubGraphQLException implements Exception {
+  GithubGraphQLException(this.message, {this.isAuthError = false});
+
+  final String message;
+  final bool isAuthError;
+
+  @override
+  String toString() => message;
+}
+
+final githubGraphQLDataSourceProvider = Provider<GithubGraphQLDataSource?>(
+  (ref) {
+    final tokenAsync = ref.watch(githubTokenProvider);
+    final token =
+        tokenAsync.maybeWhen(data: (value) => value, orElse: () => null);
+    if (token == null || token.isEmpty) {
+      return null;
+    }
+    final client = ref.watch(githubGraphQLClientProvider);
+    return GithubGraphQLDataSource(client);
+  },
+);
+
+class GithubGraphQLDataSource {
+  GithubGraphQLDataSource(this._client);
+
+  final GraphQLClient _client;
+
+  static const _repoLanguagesQuery = r'''
+    query RepoLanguages($owner: String!, $name: String!, $top: Int!) {
+      repository(owner: $owner, name: $name) {
+        languages(first: $top, orderBy: {field: SIZE, direction: DESC}) {
+          totalSize
+          edges {
+            size
+            node {
+              name
+              color
+            }
+          }
+        }
+      }
+    }
+  ''';
+
+  Future<List<RepoLanguageStat>> fetchRepoLanguages({
+    required String owner,
+    required String name,
+    int top = 5,
+  }) async {
+    final options = QueryOptions(
+      document: gql(_repoLanguagesQuery),
+      variables: <String, dynamic>{
+        'owner': owner,
+        'name': name,
+        'top': top,
+      },
+      fetchPolicy: FetchPolicy.networkOnly,
+    );
+
+    final result = await _client.query(options);
+    final exception = result.exception;
+    if (exception != null) {
+      final isAuth = _isAuthError(exception);
+      final message = exception.toString();
+      AppLogger.error(
+        'GitHub GraphQL query failed',
+        error: message,
+        area: 'github',
+      );
+      throw GithubGraphQLException(message, isAuthError: isAuth);
+    }
+
+    final repository = result.data?['repository'] as Map<String, dynamic>?;
+    if (repository == null) {
+      return const <RepoLanguageStat>[];
+    }
+    final languages = repository['languages'] as Map<String, dynamic>?;
+    if (languages == null) {
+      return const <RepoLanguageStat>[];
+    }
+    final totalSize = languages['totalSize'] as int? ?? 0;
+    final edges = (languages['edges'] as List<dynamic>? ?? [])
+        .cast<Map<String, dynamic>>();
+    if (edges.isEmpty || totalSize <= 0) {
+      return const <RepoLanguageStat>[];
+    }
+
+    final stats = edges.map((edge) {
+      final node = edge['node'] as Map<String, dynamic>? ?? const {};
+      final size = edge['size'] as int? ?? 0;
+      final name = node['name'] as String? ?? 'Unknown';
+      final color = node['color'] as String?;
+      final ratio = totalSize == 0 ? 0.0 : size / totalSize;
+      return RepoLanguageStat(
+        name: name,
+        size: size,
+        ratio: ratio,
+        color: color,
+      );
+    }).toList();
+
+    return stats;
+  }
+
+  bool _isAuthError(OperationException exception) {
+    if (exception.linkException is ServerException) {
+      final server = exception.linkException as ServerException;
+      final status = server.statusCode ?? 0;
+      if (status == 401 || status == 403) {
+        return true;
+      }
+    }
+    if (exception.graphqlErrors.isEmpty) {
+      return false;
+    }
+    return exception.graphqlErrors.any((error) {
+      final type = error.extensions?['type'];
+      final code = error.extensions?['code'];
+      return type == 'UNAUTHENTICATED' || code == 'UNAUTHENTICATED';
+    });
+  }
+}

--- a/lib/features/github/data/datasources/github_remote_data_source.dart
+++ b/lib/features/github/data/datasources/github_remote_data_source.dart
@@ -1,6 +1,8 @@
 import 'package:devhub_gpt/core/utils/app_logger.dart';
 import 'package:devhub_gpt/features/commits/data/models/commit_model.dart';
+import 'package:devhub_gpt/features/github/data/datasources/github_rest_client.dart';
 import 'package:devhub_gpt/features/github/data/models/activity_event_model.dart';
+import 'package:devhub_gpt/features/github/data/models/github_user_model.dart';
 import 'package:devhub_gpt/features/github/data/models/pull_request_model.dart';
 import 'package:devhub_gpt/features/github/data/models/repo_model.dart';
 import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
@@ -8,13 +10,12 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class GithubRemoteDataSource {
-  GithubRemoteDataSource(this._dio);
+  GithubRemoteDataSource(this._api);
 
-  final Dio _dio;
+  final GithubRestClient _api;
 
-  Future<Map<String, dynamic>> getCurrentUser() async {
-    final res = await _dio.get<Map<String, dynamic>>('/user');
-    return res.data as Map<String, dynamic>;
+  Future<GithubUserModel> getCurrentUser() async {
+    return _api.getCurrentUser();
   }
 
   Future<List<RepoModel>> listUserRepos({
@@ -22,20 +23,14 @@ class GithubRemoteDataSource {
     int perPage = 20,
     String? query,
   }) async {
-    final params = <String, dynamic>{
-      'page': page,
-      'per_page': perPage,
-      'sort': 'updated',
-      'direction': 'desc',
-      'affiliation': 'owner,collaborator,organization_member',
-      'visibility': 'all',
-    };
-    final resp = await _dio.get<List<dynamic>>(
-      '/user/repos',
-      queryParameters: params,
+    final models = await _api.listUserRepos(
+      page: page,
+      perPage: perPage,
+      sort: 'updated',
+      direction: 'desc',
+      affiliation: 'owner,collaborator,organization_member',
+      visibility: 'all',
     );
-    final list = (resp.data as List).cast<Map<String, dynamic>>();
-    final models = list.map(RepoModel.fromJson).toList();
     if (query != null && query.isNotEmpty) {
       final q = query.toLowerCase();
       return models
@@ -53,9 +48,7 @@ class GithubRemoteDataSource {
     required String owner,
     required String repo,
   }) async {
-    final resp = await _dio.get<List<dynamic>>('/repos/$owner/$repo/events');
-    final list = (resp.data as List).cast<Map<String, dynamic>>();
-    return list.map(ActivityEventModel.fromJson).toList();
+    return _api.getRepoActivity(owner, repo);
   }
 
   Future<List<CommitModel>> listRepoCommits({
@@ -63,12 +56,11 @@ class GithubRemoteDataSource {
     required String repo,
     int perPage = 20,
   }) async {
-    final resp = await _dio.get<List<dynamic>>(
-      '/repos/$owner/$repo/commits',
-      queryParameters: {'per_page': perPage},
+    return _api.listRepoCommits(
+      owner,
+      repo,
+      perPage: perPage,
     );
-    final list = (resp.data as List).cast<Map<String, dynamic>>();
-    return list.map(CommitModel.fromJson).toList();
   }
 
   Future<List<PullRequestModel>> listPullRequests({
@@ -77,17 +69,22 @@ class GithubRemoteDataSource {
     String state = 'open',
     int perPage = 20,
   }) async {
-    final resp = await _dio.get<List<dynamic>>(
-      '/repos/$owner/$repo/pulls',
-      queryParameters: {'state': state, 'per_page': perPage},
+    return _api.listPullRequests(
+      owner,
+      repo,
+      state: state,
+      perPage: perPage,
     );
-    final list = (resp.data as List).cast<Map<String, dynamic>>();
-    return list.map(PullRequestModel.fromJson).toList();
   }
 }
 
-final githubRemoteDataSourceProvider = Provider<GithubRemoteDataSource>((ref) {
+final githubRestClientProvider = Provider<GithubRestClient>((ref) {
   final dio = ref.watch(githubDioProvider);
+  return GithubRestClient(dio);
+});
+
+final githubRemoteDataSourceProvider = Provider<GithubRemoteDataSource>((ref) {
+  final api = ref.watch(githubRestClientProvider);
   AppLogger.info('Init GithubRemoteDataSource', area: 'github');
-  return GithubRemoteDataSource(dio);
+  return GithubRemoteDataSource(api);
 });

--- a/lib/features/github/data/datasources/github_rest_client.dart
+++ b/lib/features/github/data/datasources/github_rest_client.dart
@@ -1,0 +1,69 @@
+import 'package:devhub_gpt/features/commits/data/models/commit_model.dart';
+import 'package:devhub_gpt/features/github/data/models/activity_event_model.dart';
+import 'package:devhub_gpt/features/github/data/models/github_user_model.dart';
+import 'package:devhub_gpt/features/github/data/models/pull_request_model.dart';
+import 'package:devhub_gpt/features/github/data/models/repo_model.dart';
+import 'package:dio/dio.dart' hide Headers;
+import 'package:retrofit/retrofit.dart';
+
+part 'github_rest_client.g.dart';
+
+@RestApi()
+abstract class GithubRestClient {
+  factory GithubRestClient(Dio dio, {String baseUrl}) = _GithubRestClient;
+
+  @GET('/user')
+  Future<GithubUserModel> getCurrentUser();
+
+  @GET('/user/repos')
+  Future<List<RepoModel>> listUserRepos({
+    @Query('page') int page = 1,
+    @Query('per_page') int perPage = 20,
+    @Query('sort') String sort = 'updated',
+    @Query('direction') String direction = 'desc',
+    @Query('affiliation')
+    String affiliation = 'owner,collaborator,organization_member',
+    @Query('visibility') String visibility = 'all',
+  });
+
+  @GET('/user/repos')
+  Future<HttpResponse<List<RepoModel>>> listUserReposWithResponse({
+    @Query('page') int page = 1,
+    @Query('per_page') int perPage = 20,
+    @Query('sort') String sort = 'updated',
+    @Query('direction') String direction = 'desc',
+    @Query('affiliation')
+    String affiliation = 'owner,collaborator,organization_member',
+    @Query('visibility') String visibility = 'all',
+    @Header('If-None-Match') String? ifNoneMatch,
+  });
+
+  @GET('/repos/{owner}/{repo}/events')
+  Future<List<ActivityEventModel>> getRepoActivity(
+    @Path('owner') String owner,
+    @Path('repo') String repo,
+  );
+
+  @GET('/repos/{owner}/{repo}/commits')
+  Future<List<CommitModel>> listRepoCommits(
+    @Path('owner') String owner,
+    @Path('repo') String repo, {
+    @Query('per_page') int perPage = 20,
+  });
+
+  @GET('/repos/{owner}/{repo}/commits')
+  Future<HttpResponse<List<CommitModel>>> listRepoCommitsWithResponse(
+    @Path('owner') String owner,
+    @Path('repo') String repo, {
+    @Query('per_page') int perPage = 20,
+    @Header('If-None-Match') String? ifNoneMatch,
+  });
+
+  @GET('/repos/{owner}/{repo}/pulls')
+  Future<List<PullRequestModel>> listPullRequests(
+    @Path('owner') String owner,
+    @Path('repo') String repo, {
+    @Query('state') String state = 'open',
+    @Query('per_page') int perPage = 20,
+  });
+}

--- a/lib/features/github/data/datasources/github_rest_client.g.dart
+++ b/lib/features/github/data/datasources/github_rest_client.g.dart
@@ -1,0 +1,307 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'github_rest_client.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter
+
+class _GithubRestClient implements GithubRestClient {
+  _GithubRestClient(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<GithubUserModel> getCurrentUser() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<GithubUserModel>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/user',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late GithubUserModel _value;
+    try {
+      _value = GithubUserModel.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<List<RepoModel>> listUserRepos({
+    int page = 1,
+    int perPage = 20,
+    String sort = 'updated',
+    String direction = 'desc',
+    String affiliation = 'owner,collaborator,organization_member',
+    String visibility = 'all',
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'page': page,
+      r'per_page': perPage,
+      r'sort': sort,
+      r'direction': direction,
+      r'affiliation': affiliation,
+      r'visibility': visibility,
+    };
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<RepoModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/user/repos',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<RepoModel> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => RepoModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<HttpResponse<List<RepoModel>>> listUserReposWithResponse({
+    int page = 1,
+    int perPage = 20,
+    String sort = 'updated',
+    String direction = 'desc',
+    String affiliation = 'owner,collaborator,organization_member',
+    String visibility = 'all',
+    String? ifNoneMatch,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'page': page,
+      r'per_page': perPage,
+      r'sort': sort,
+      r'direction': direction,
+      r'affiliation': affiliation,
+      r'visibility': visibility,
+    };
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{r'If-None-Match': ifNoneMatch};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<List<RepoModel>>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/user/repos',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<RepoModel> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => RepoModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<List<ActivityEventModel>> getRepoActivity(
+    String owner,
+    String repo,
+  ) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<ActivityEventModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/repos/${owner}/${repo}/events',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<ActivityEventModel> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) =>
+                ActivityEventModel.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<List<CommitModel>> listRepoCommits(
+    String owner,
+    String repo, {
+    int perPage = 20,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'per_page': perPage};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<CommitModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/repos/${owner}/${repo}/commits',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<CommitModel> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => CommitModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<HttpResponse<List<CommitModel>>> listRepoCommitsWithResponse(
+    String owner,
+    String repo, {
+    int perPage = 20,
+    String? ifNoneMatch,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'per_page': perPage};
+    queryParameters.removeWhere((k, v) => v == null);
+    final _headers = <String, dynamic>{r'If-None-Match': ifNoneMatch};
+    _headers.removeWhere((k, v) => v == null);
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<HttpResponse<List<CommitModel>>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/repos/${owner}/${repo}/commits',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<CommitModel> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => CommitModel.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    final httpResponse = HttpResponse(_value, _result);
+    return httpResponse;
+  }
+
+  @override
+  Future<List<PullRequestModel>> listPullRequests(
+    String owner,
+    String repo, {
+    String state = 'open',
+    int perPage = 20,
+  }) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{
+      r'state': state,
+      r'per_page': perPage,
+    };
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<PullRequestModel>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/repos/${owner}/${repo}/pulls',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<PullRequestModel> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => PullRequestModel.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/features/github/domain/entities/repo_language_stat.dart
+++ b/lib/features/github/domain/entities/repo_language_stat.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class RepoLanguageStat extends Equatable {
+  const RepoLanguageStat({
+    required this.name,
+    required this.size,
+    required this.ratio,
+    this.color,
+  });
+
+  final String name;
+  final int size;
+  final double ratio;
+  final String? color;
+
+  String get percentageLabel => '${(ratio * 100).toStringAsFixed(1)}%';
+
+  @override
+  List<Object?> get props => [name, size, ratio, color];
+}

--- a/lib/features/github/domain/repositories/github_repository.dart
+++ b/lib/features/github/domain/repositories/github_repository.dart
@@ -4,6 +4,7 @@ import 'package:devhub_gpt/features/github/domain/entities/activity_event.dart';
 import 'package:devhub_gpt/features/github/domain/entities/github_user.dart';
 import 'package:devhub_gpt/features/github/domain/entities/pull_request.dart';
 import 'package:devhub_gpt/features/github/domain/entities/repo.dart';
+import 'package:devhub_gpt/features/github/domain/entities/repo_language_stat.dart';
 
 abstract class GithubRepository {
   Future<Either<Failure, List<Repo>>> getUserRepos({
@@ -20,4 +21,9 @@ abstract class GithubRepository {
     String state = 'open',
   });
   Future<Either<Failure, GithubUser>> getCurrentUser();
+  Future<Either<Failure, List<RepoLanguageStat>>> getRepoLanguages(
+    String owner,
+    String repo, {
+    int top,
+  });
 }

--- a/lib/shared/providers/github_graphql_client_provider.dart
+++ b/lib/shared/providers/github_graphql_client_provider.dart
@@ -1,0 +1,24 @@
+import 'package:devhub_gpt/shared/providers/github_client_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphql/client.dart';
+
+final githubGraphQLClientProvider = Provider<GraphQLClient>((ref) {
+  final tokenAsync = ref.watch(githubTokenProvider);
+  final token =
+      tokenAsync.maybeWhen(data: (value) => value, orElse: () => null);
+  final headers = <String, String>{
+    'Accept': 'application/vnd.github+json',
+    'User-Agent': 'devhub-gpt-app',
+    if (token != null && token.isNotEmpty) 'Authorization': 'Bearer $token',
+  };
+
+  final link = HttpLink(
+    'https://api.github.com/graphql',
+    defaultHeaders: headers,
+  );
+
+  return GraphQLClient(
+    cache: GraphQLCache(store: InMemoryStore()),
+    link: link,
+  );
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -615,6 +615,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
+  gql:
+    dependency: transitive
+    description:
+      name: gql
+      sha256: "67c32325eb55c15f526f0f5e7d8b38a463dbff2ec3c2e046be4a1a95f0dc93d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  gql_dedupe_link:
+    dependency: transitive
+    description:
+      name: gql_dedupe_link
+      sha256: "10bee0564d67c24e0c8bd08bd56e0682b64a135e58afabbeed30d85d5e9fea96"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4-alpha+1715521079596"
+  gql_error_link:
+    dependency: transitive
+    description:
+      name: gql_error_link
+      sha256: dd0f3fbfbcec848ea050507470cdb5d3dc47d29544ae11044a1c883cbe159ccc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  gql_exec:
+    dependency: transitive
+    description:
+      name: gql_exec
+      sha256: "394944626fae900f1d34343ecf2d62e44eb984826189c8979d305f0ae5846e38"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1-alpha+1699813812660"
+  gql_http_link:
+    dependency: transitive
+    description:
+      name: gql_http_link
+      sha256: "07635e85a4f313836904961904417fd27844fe8f68f77b410a4e6b81d8e9202e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  gql_link:
+    dependency: transitive
+    description:
+      name: gql_link
+      sha256: "0730276ce3a6a0ced073194ff923a8d99b3c78e442cbf096eb54fd0c3fa9f974"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  gql_transform_link:
+    dependency: transitive
+    description:
+      name: gql_transform_link
+      sha256: b3bb06a6991bc5c9d877e2757455f80e2c14dc684b8327bedae4f4ee67afae8b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  graphql:
+    dependency: "direct main"
+    description:
+      name: graphql
+      sha256: "2011435a7fea92fff5b02c77550a54f89427a3c33c92cd2fccfd3aa87ed3727d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.2"
   graphs:
     dependency: transitive
     description:
@@ -836,6 +900,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  normalize:
+    dependency: transitive
+    description:
+      name: normalize
+      sha256: f78bf0552b9640c76369253f0b8fdabad4f3fbfc06bdae9359e71bee9a5b071b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   package_config:
     dependency: transitive
     description:
@@ -1028,6 +1100,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   scroll_to_index:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   dio_cache_interceptor: ^3.5.0
   dio_smart_retry: ^7.0.1
   retrofit: ^4.7.2
+  graphql: ^5.2.0
   pretty_dio_logger: ^1.4.0
   markdown_widget: ^2.3.2+8
   url_launcher: ^6.3.2

--- a/test/unit/features/commits/data/repositories/github_commits_repository_test.dart
+++ b/test/unit/features/commits/data/repositories/github_commits_repository_test.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:io';
+import 'dart:io';
 import 'package:devhub_gpt/core/db/app_database.dart';
 import 'package:devhub_gpt/features/commits/data/models/commit_model.dart' as m;
 import 'package:devhub_gpt/features/commits/data/repositories/github_commits_repository.dart';
@@ -10,60 +10,10 @@ import 'package:devhub_gpt/features/github/domain/entities/repo.dart' as domain;
 import 'package:dio/dio.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 
-class _DsOk extends GithubRemoteDataSource {
-  _DsOk() : super(Dio());
-  @override
-  Future<List<RepoModel>> listUserRepos({
-    int page = 1,
-    int perPage = 20,
-    String? query,
-  }) async {
-    return [
-      RepoModel(
-        id: 1,
-        name: 'a',
-        fullName: 'u/a',
-        stargazersCount: 1,
-        forksCount: 0,
-      ),
-    ];
-  }
-
-  @override
-  Future<List<m.CommitModel>> listRepoCommits({
-    required String owner,
-    required String repo,
-    int perPage = 20,
-  }) async {
-    return [
-      m.CommitModel(
-        id: 'c1',
-        message: 'msg1',
-        author: 'a1',
-        date: DateTime(2024, 1, 1),
-      ),
-      m.CommitModel(
-        id: 'c2',
-        message: 'msg2',
-        author: 'a2',
-        date: DateTime(2024, 1, 2),
-      ),
-    ];
-  }
-}
-
-class _DsFail extends GithubRemoteDataSource {
-  _DsFail() : super(Dio());
-  @override
-  Future<List<RepoModel>> listUserRepos({
-    int page = 1,
-    int perPage = 20,
-    String? query,
-  }) async {
-    throw DioException(requestOptions: RequestOptions(path: '/user/repos'));
-  }
-}
+class _MockGithubRemoteDataSource extends Mock
+    implements GithubRemoteDataSource {}
 
 void main() {
   test('listRecent caches commits on success', () async {
@@ -72,8 +22,40 @@ void main() {
     }
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final dao = GithubLocalDao(db);
+    final ds = _MockGithubRemoteDataSource();
+    when(() =>
+        ds.listUserRepos(
+            page: any(named: 'page'),
+            perPage: any(named: 'perPage'),
+            query: any(named: 'query'))).thenAnswer((_) async => [
+          RepoModel(
+            id: 1,
+            name: 'a',
+            fullName: 'u/a',
+            stargazersCount: 1,
+            forksCount: 0,
+          ),
+        ]);
+    when(() => ds.listRepoCommits(
+          owner: any(named: 'owner'),
+          repo: any(named: 'repo'),
+          perPage: any(named: 'perPage'),
+        )).thenAnswer((_) async => [
+          m.CommitModel(
+            id: 'c1',
+            message: 'msg1',
+            author: 'a1',
+            date: DateTime(2024, 1, 1),
+          ),
+          m.CommitModel(
+            id: 'c2',
+            message: 'msg2',
+            author: 'a2',
+            date: DateTime(2024, 1, 2),
+          ),
+        ]);
     final repo = GithubCommitsRepository(
-      _DsOk(),
+      ds,
       () async => {'Authorization': 'Bearer x'},
       dao: dao,
       tokenScope: () async => 'scope1',
@@ -121,8 +103,15 @@ void main() {
       ),
     ]);
 
+    final ds = _MockGithubRemoteDataSource();
+    when(() => ds.listUserRepos(
+        page: any(named: 'page'),
+        perPage: any(named: 'perPage'),
+        query: any(named: 'query'))).thenThrow(
+      DioException(requestOptions: RequestOptions(path: '/user/repos')),
+    );
     final repo = GithubCommitsRepository(
-      _DsFail(),
+      ds,
       () async => {'Authorization': 'Bearer x'},
       dao: dao,
       tokenScope: () async => scope,

--- a/test/unit/features/github/data/datasources/github_graphql_data_source_test.dart
+++ b/test/unit/features/github/data/datasources/github_graphql_data_source_test.dart
@@ -1,0 +1,94 @@
+import 'package:devhub_gpt/features/github/data/datasources/github_graphql_data_source.dart';
+import 'package:devhub_gpt/features/github/domain/entities/repo_language_stat.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql/client.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockGraphQLClient extends Mock implements GraphQLClient {}
+
+void main() {
+  late _MockGraphQLClient client;
+  late GithubGraphQLDataSource dataSource;
+
+  setUpAll(() {
+    registerFallbackValue(
+      QueryOptions(document: gql('query Test { viewer { login } }')),
+    );
+  });
+
+  setUp(() {
+    client = _MockGraphQLClient();
+    dataSource = GithubGraphQLDataSource(client);
+  });
+
+  test('fetchRepoLanguages returns stats when data is available', () async {
+    when(() => client.query(any())).thenAnswer((invocation) async {
+      final options = invocation.positionalArguments.first as QueryOptions;
+      expect(options.variables['owner'], 'owner');
+      expect(options.variables['name'], 'repo');
+      expect(options.variables['top'], 5);
+      return QueryResult(
+        options: options,
+        data: <String, dynamic>{
+          'repository': {
+            'languages': {
+              'totalSize': 300,
+              'edges': [
+                {
+                  'size': 150,
+                  'node': {'name': 'Dart', 'color': '#00B4AB'},
+                },
+                {
+                  'size': 90,
+                  'node': {'name': 'TypeScript', 'color': '#3178C6'},
+                },
+                {
+                  'size': 60,
+                  'node': {'name': 'Other', 'color': null},
+                },
+              ],
+            },
+          },
+        },
+        source: QueryResultSource.network,
+      );
+    });
+
+    final stats = await dataSource.fetchRepoLanguages(
+      owner: 'owner',
+      name: 'repo',
+    );
+
+    expect(stats, hasLength(3));
+    expect(stats.first, isA<RepoLanguageStat>());
+    expect(stats.first.name, 'Dart');
+    expect(stats.first.percentageLabel, '50.0%');
+  });
+
+  test('fetchRepoLanguages throws auth error for UNAUTHENTICATED', () async {
+    when(() => client.query(any())).thenAnswer((invocation) async {
+      final options = invocation.positionalArguments.first as QueryOptions;
+      return QueryResult(
+        options: options,
+        source: QueryResultSource.network,
+        exception: OperationException(
+          graphqlErrors: [
+            const GraphQLError(
+              message: 'Bad credentials',
+              extensions: {'type': 'UNAUTHENTICATED'},
+            ),
+          ],
+        ),
+      );
+    });
+
+    expect(
+      () => dataSource.fetchRepoLanguages(owner: 'o', name: 'r'),
+      throwsA(isA<GithubGraphQLException>().having(
+        (e) => e.isAuthError,
+        'isAuthError',
+        isTrue,
+      )),
+    );
+  });
+}

--- a/test/unit/features/github/presentation/providers/github_providers_test.dart
+++ b/test/unit/features/github/presentation/providers/github_providers_test.dart
@@ -4,6 +4,7 @@ import 'package:devhub_gpt/features/github/domain/entities/activity_event.dart';
 import 'package:devhub_gpt/features/github/domain/entities/github_user.dart';
 import 'package:devhub_gpt/features/github/domain/entities/pull_request.dart';
 import 'package:devhub_gpt/features/github/domain/entities/repo.dart';
+import 'package:devhub_gpt/features/github/domain/entities/repo_language_stat.dart';
 import 'package:devhub_gpt/features/github/domain/repositories/github_repository.dart';
 import 'package:devhub_gpt/features/github/presentation/providers/github_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,7 +15,8 @@ class _RepoFake implements GithubRepository {
   Future<Either<Failure, List<ActivityEvent>>> getRepoActivity(
     String owner,
     String repo,
-  ) async => const Right(<ActivityEvent>[]);
+  ) async =>
+      const Right(<ActivityEvent>[]);
 
   @override
   Future<Either<Failure, List<Repo>>> getUserRepos({
@@ -45,12 +47,21 @@ class _RepoFake implements GithubRepository {
     String owner,
     String repo, {
     String state = 'open',
-  }) async => const Right(<PullRequest>[]);
+  }) async =>
+      const Right(<PullRequest>[]);
 
   @override
   Future<Either<Failure, GithubUser>> getCurrentUser() async =>
       // ignore: prefer_const_constructors
       Right(const GithubUser(login: 'u', avatarUrl: 'http://x'));
+
+  @override
+  Future<Either<Failure, List<RepoLanguageStat>>> getRepoLanguages(
+    String owner,
+    String repo, {
+    int top = 5,
+  }) async =>
+      const Right(<RepoLanguageStat>[]);
 }
 
 void main() {

--- a/test/unit/subscriptions/stripe_subscription_api_test.dart
+++ b/test/unit/subscriptions/stripe_subscription_api_test.dart
@@ -9,6 +9,7 @@ class MockDio extends Mock implements Dio {}
 void main() {
   setUpAll(() {
     registerFallbackValue(Uri.parse('https://example.com'));
+    registerFallbackValue(Options());
   });
 
   group('StripeSubscriptionApi', () {
@@ -39,6 +40,7 @@ void main() {
         () => dio.postUri<Map<String, dynamic>>(
           any(),
           data: any(named: 'data'),
+          options: any(named: 'options'),
         ),
       ).thenAnswer(
         (_) async => Response(
@@ -57,6 +59,7 @@ void main() {
             'https://backend.test/api/subscriptions/create-checkout-session',
           ),
           data: {'priceId': 'price_123'},
+          options: any(named: 'options'),
         ),
       ).called(1);
     });
@@ -93,6 +96,7 @@ void main() {
         () => dio.postUri<Map<String, dynamic>>(
           any(),
           data: any(named: 'data'),
+          options: any(named: 'options'),
         ),
       ).thenAnswer(
         (_) async => Response(
@@ -113,6 +117,7 @@ void main() {
         () => dio.postUri<Map<String, dynamic>>(
           any(),
           data: any(named: 'data'),
+          options: any(named: 'options'),
         ),
       ).thenThrow(
         DioException(


### PR DESCRIPTION
## Summary
- add a Retrofit-based GitHub REST client and refactor the remote data source/repository to use strongly typed models
- introduce a GitHub GraphQL client and data source for repository language statistics with repository/provider wiring
- surface language stats in the repositories UI and add unit tests covering the new data source and repository behavior

## Testing
- flutter test test/unit/features/github/data/datasources/github_graphql_data_source_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68dbf20b53a48333a0c9da3b6a6b7389